### PR TITLE
Fix CLI INT mode to keep console at -> prompt until /bye

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,10 +225,16 @@ startSerialListener([&](const std::string& line) {
     std::cout << "\033[38;2;255;215;0mAImaster CLI\033[0m\n\033[38;2;255;239;184mType HELP for a list of commands.\033[0m\n";
 
     while (true) {
-        std::string prompt = ReadAwait_IsActive()
-    ? ": "
-    : ("[38;2;255;239;184m" + config.ollama_model + "> [0m");
-char* input = readline(prompt.c_str());
+        std::string prompt;
+        if (ReadAwait_IsActive()) {
+            prompt = ": ";
+        } else if (SerialINT_IsActive()) {
+            prompt = "-> ";
+        } else {
+            prompt = "[38;2;255;239;184m" + config.ollama_model + "> [0m";
+        }
+
+        char* input = readline(prompt.c_str());
         if (!input) break;
 
         if (*input) {
@@ -265,7 +271,13 @@ char* input = readline(prompt.c_str());
         continue;
     }
 }
-Json::Value result = execute_command(command, config, CommandSource::CONSOLE);
+        if (SerialINT_IsActive()) {
+            setCurrentCommandSource(CommandSource::CONSOLE);
+            SerialINT_HandleLine(command, config);
+            continue;
+        }
+
+        Json::Value result = execute_command(command, config, CommandSource::CONSOLE);
     }
 
     // Save history on exit
@@ -273,4 +285,3 @@ Json::Value result = execute_command(command, config, CommandSource::CONSOLE);
 
     return 0;
 }
-

--- a/src/ollama_client.cpp
+++ b/src/ollama_client.cpp
@@ -355,18 +355,18 @@ void SerialINT_HandleLine(const std::string& line, AppConfig& config) {
     if (line == "/bye") {
         g_serial_int_active.store(false, std::memory_order_relaxed);
         route_output("[Returning to main prompt]", true);
-        route_output(modelPrompt(config, "-> "), false);
+        route_output(modelPrompt(config, "> "), false);
         return;
     }
         if (line == "/n") {
         g_serial_int_active.store(false, std::memory_order_relaxed);
-        route_output(modelPrompt(config, "-> "), false);
+        route_output(modelPrompt(config, "> "), false);
     }
     // Try RAG first (if active and enabled)
     std::string rag_answer;
     if (rag_int::TryRAGAnswer(line, rag_answer, /*k=*/5, /*threshold=*/0.2)) {
         route_output(rag_answer, true);
-        route_output(modelPrompt(config, "-> "), false);
+        route_output("-> ", false);
         return;
     }
     // Fall back to normal LLM


### PR DESCRIPTION
### Motivation
- The interactive `INT` mode should keep the console at the `-> ` prompt and accept user-entered lines as interactive chat until the user issues `/bye` instead of returning immediately to the model prompt.
- Inputs typed in the console while `INT` is active must be routed into the interactive handler rather than treated as top-level commands.

### Description
- Updated prompt selection in `src/main.cpp` so the REPL uses `"-> "` when `SerialINT_IsActive()` is true, `":"` when `ReadAwait_IsActive()`, and the normal model prompt otherwise.
- When `SerialINT_IsActive()` in the main input loop, calls to console input are forwarded to `SerialINT_HandleLine(command, config)` (after `setCurrentCommandSource(CommandSource::CONSOLE)`), and the loop continues without executing a top-level command.
- Adjusted `SerialINT_HandleLine` in `src/ollama_client.cpp` to return to the normal model prompt (`"> "`) on `/bye` and `/n`, and to emit `"-> "` directly for follow-up prompts after a RAG response so the interactive prompt remains consistent.

### Testing
- Ran `make -j4` to build the project and validate changes; the build failed in this environment due to missing system headers/libraries (`json/json.h` and `libserialport.h`), which are unrelated to the logic changes in this PR and prevent a full compile here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999bdf59464832d9197b975cb2dcc2c)