### PR TITLE
Make RAG console commands case-insensitive

### DIFF
--- a/include/rag_console_commands.hpp
+++ b/include/rag_console_commands.hpp
@@ -4,6 +4,8 @@
 #include <vector>
 #include <iostream>
 #include <iomanip>
+#include <algorithm>
+#include <cctype>
 #include <jsoncpp/json/json.h>
 #include "rag_adapter.hpp"
 #include "rag_state.hpp"
@@ -14,12 +16,18 @@ inline void __rag_tokenize(const std::string& line, std::vector<std::string>& to
     while (iss >> t) toks.push_back(t);
 }
 
+inline std::string __rag_upper(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return s;
+}
+
 // Header-only console handler so no separate .cpp is required.
 inline bool HandleRAGConsoleCommand(const std::string& line, Json::Value& out) {
     std::vector<std::string> tokens;
     __rag_tokenize(line, tokens);
     if (tokens.empty()) return false;
-    const std::string& cmd = tokens[0];
+    const std::string cmd = __rag_upper(tokens[0]);
 
     // RAG_INGEST <folder>
     if (cmd == "RAG_INGEST") {
@@ -82,7 +90,8 @@ inline bool HandleRAGConsoleCommand(const std::string& line, Json::Value& out) {
 
     // RAG_SESSION <SET|SHOW|CLEAR> [sid]
     if (cmd == "RAG_SESSION") {
-        if (tokens.size()>=2 && tokens[1]=="SET") {
+        const std::string action = tokens.size() >= 2 ? __rag_upper(tokens[1]) : "";
+        if (action == "SET") {
             if (tokens.size()<3) {
                 std::cout << "Usage: RAG_SESSION SET <sid>\n";
                 out["ok"] = false; out["error"] = "usage";
@@ -91,11 +100,11 @@ inline bool HandleRAGConsoleCommand(const std::string& line, Json::Value& out) {
             rag_state::SetActiveSession(tokens[2]);
             std::cout << "RAG session set.\n";
             out["ok"] = true; out["session_id"] = tokens[2];
-        } else if (tokens.size()>=2 && tokens[1]=="SHOW") {
+        } else if (action == "SHOW") {
             auto sid = rag_state::GetActiveSession();
             std::cout << (sid.empty() ? "<none>" : sid) << "\n";
             out["ok"] = true; out["session_id"] = sid;
-        } else if (tokens.size()>=2 && tokens[1]=="CLEAR") {
+        } else if (action == "CLEAR") {
             rag_state::SetActiveSession("");
             std::cout << "RAG session cleared.\n";
             out["ok"] = true;

--- a/src/rag_console_commands.cpp
+++ b/src/rag_console_commands.cpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include <iostream>
 #include <iomanip>
+#include <algorithm>
+#include <cctype>
 
 static void tokenize(const std::string& line, std::vector<std::string>& toks) {
     std::istringstream iss(line);
@@ -13,12 +15,18 @@ static void tokenize(const std::string& line, std::vector<std::string>& toks) {
     while (iss >> t) toks.push_back(t);
 }
 
+static std::string upper(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return s;
+}
+
 bool HandleRAGConsoleCommand(const std::string& line, Json::Value& out) {
     std::vector<std::string> tokens;
     tokenize(line, tokens);
     if (tokens.empty()) return false;
 
-    const std::string& cmd = tokens[0];
+    const std::string cmd = upper(tokens[0]);
 
     // RAG_INGEST <folder>
     if (cmd == "RAG_INGEST") {
@@ -81,7 +89,8 @@ bool HandleRAGConsoleCommand(const std::string& line, Json::Value& out) {
 
     // RAG_SESSION <SET|SHOW|CLEAR> [sid]
     if (cmd == "RAG_SESSION") {
-        if (tokens.size()>=2 && tokens[1]=="SET") {
+        const std::string action = tokens.size() >= 2 ? upper(tokens[1]) : "";
+        if (action == "SET") {
             if (tokens.size()<3) {
                 std::cout << "Usage: RAG_SESSION SET <sid>\n";
                 out["ok"] = false; out["error"] = "usage";
@@ -90,11 +99,11 @@ bool HandleRAGConsoleCommand(const std::string& line, Json::Value& out) {
             rag_state::SetActiveSession(tokens[2]);
             std::cout << "RAG session set.\n";
             out["ok"] = true; out["session_id"] = tokens[2];
-        } else if (tokens.size()>=2 && tokens[1]=="SHOW") {
+        } else if (action == "SHOW") {
             auto sid = rag_state::GetActiveSession();
             std::cout << (sid.empty() ? "<none>" : sid) << "\n";
             out["ok"] = true; out["session_id"] = sid;
-        } else if (tokens.size()>=2 && tokens[1]=="CLEAR") {
+        } else if (action == "CLEAR") {
             rag_state::SetActiveSession("");
             std::cout << "RAG session cleared.\n";
             out["ok"] = true;


### PR DESCRIPTION
### Motivation
- Improve UX by allowing RAG console commands and subcommands to be entered in any case (e.g. `rag_ask`, `Rag_Show`, `RAG_session set`) so handlers match consistently.
- Ensure both the header-only and .cpp console handlers behave identically to avoid surprising mismatches between build paths.

### Description
- Added `#include <algorithm>` and `#include <cctype>` and implemented `__rag_upper` (`upper` in .cpp) to normalize tokens to uppercase before dispatch.
- Changed top-level command extraction to use the uppercase-normalized token so `RAG_INGEST`, `RAG_SHOW`, and `RAG_ASK` are matched case-insensitively in `HandleRAGConsoleCommand` (both header and .cpp implementations).
- Normalized the `RAG_SESSION` action token and switched the `SET`/`SHOW`/`CLEAR` checks to compare against the uppercased `action` variable in both handlers for consistent subcommand handling.

### Testing
- Performed a syntax-only compile check with `g++ -std=c++17 -Iinclude -Isrc -fsyntax-only src/rag_console_commands.cpp`, which failed in this environment due to a missing `jsoncpp/json/json.h` dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d08a30ac832d8917ad16ffe7bc54)