### PR TITLE
Handle RAG sentinel responses with fallback

### DIFF
--- a/src/rag_int_bridge.cpp
+++ b/src/rag_int_bridge.cpp
@@ -2,6 +2,14 @@
 #include "rag_state.hpp"
 #include "rag_adapter.hpp"
 #include <atomic>
+#include <iostream>
+
+namespace {
+bool IsRAGSentinelResponse(const std::string& response) {
+    return response.find("No relevant context found in the document to answer your question.") != std::string::npos ||
+           response.find("Invalid or unknown session_id") != std::string::npos;
+}
+}
 
 namespace rag_int {
 static std::atomic<bool> g_enabled{true};
@@ -11,6 +19,10 @@ bool TryRAGAnswer(const std::string& user_input, std::string& out_answer, int k,
     if (!Enabled()) return false;
     if (!rag_state::HasActiveSession()) return false;
     out_answer = AIMaster_RAG_Ask(rag_state::GetActiveSession(), user_input, k, threshold);
+    if (IsRAGSentinelResponse(out_answer)) {
+        std::cerr << "[RAG miss; using base model]" << std::endl;
+        return false;
+    }
     return !out_answer.empty();
 }
 } // namespace rag_int


### PR DESCRIPTION
### Motivation
- Ensure sentinel RAG responses (e.g. `No relevant context found in the document to answer your question.` and `Invalid or unknown session_id`) are recognized as RAG misses so callers fall back to `sendMessageToOllama` instead of treating them as valid answers.

### Description
- Added a small helper `IsRAGSentinelResponse` and `#include <iostream>`, and updated `rag_int::TryRAGAnswer` to log a one-line notice (`[RAG miss; using base model]`) and return `false` when a sentinel response is detected, while leaving successful non-empty RAG answers unchanged.

### Testing
- Ran `make -j2`, which failed in this environment due to a missing external header (`json/json.h`); this failure is unrelated to the change and no further automated tests were run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999dcd25aa4832db53bad8fc7281175)