### PR TITLE
Guard Ollama model parsing against invalid JSON shapes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,9 +95,9 @@ static std::vector<std::string> fetch_ollama_models(const std::string& chat_url,
         error = "JSON parse error: " + errs;
         return models;
     }
-    if (root.isMember("models") && root["models"].isArray()) {
+    if (root.isObject() && root.isMember("models") && root["models"].isArray()) {
         for (const auto& m : root["models"]) {
-            if (m.isMember("name") && m["name"].isString()) {
+            if (m.isObject() && m.isMember("name") && m["name"].isString()) {
                 models.push_back(m["name"].asString());
             }
         }

--- a/src/ollama_client.cpp
+++ b/src/ollama_client.cpp
@@ -106,11 +106,11 @@ static std::vector<std::string> fetch_ollama_models(const std::string& chat_url,
         error = std::string("JSON parse error: ") + errs;
         return models;
     }
-    if (root.isMember("models") && root["models"].isArray()) {
+    if (root.isObject() && root.isMember("models") && root["models"].isArray()) {
         for (const auto& m : root["models"]) {
-            if (m.isMember("name") && m["name"].isString()) {
+            if (m.isObject() && m.isMember("name") && m["name"].isString()) {
                 models.push_back(m["name"].asString());
-            } else if (m.isMember("model") && m["model"].isString()) {
+            } else if (m.isObject() && m.isMember("model") && m["model"].isString()) {
                 models.push_back(m["model"].asString());
             }
         }


### PR DESCRIPTION
### Motivation
- Prevent startup crashes caused by `Json::LogicError` when the Ollama `/api/tags` response is not a JSON object or contains non-object array entries. 
- Ensure the app fails gracefully (with a warning) instead of throwing when the tags payload has an unexpected shape.

### Description
- Add `root.isObject()` checks before accessing `root.isMember("models")` and verifying `root["models"]` in startup model discovery in `src/main.cpp`.
- Add `m.isObject()` guards before calling `isMember("name")` / `isMember("model")` on each entry and similarly validate fields in `src/ollama_client.cpp`.
- Changes modify parsing logic only and keep existing behavior for well-formed responses while avoiding calls that can throw on non-object values.

### Testing
- Ran a build attempt with `make -j4`, which exercised compilation but failed due to missing development headers (`json/json.h` and `libserialport.h`) in the environment so a full rebuild/run verification could not be completed.
- Confirmed the code changes were compiled by the compiler up to the missing-header errors and committed the patch to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a00d91288832d8ce77e630c19892d)