### PR TITLE
Add /speak CLI toggle and lightweight TTS pipeline (Quick‑Piper-style endpoint)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ OBJS = \
   src/serial_handler.o \
   src/chat_provider.o \
   src/ollama_client.o \
+  src/tts.o \
   src/rag_session.o \
   src/rag_adapter.o \
   src/rag_int_bridge.o \
@@ -30,7 +31,7 @@ clean:
 	rm -f $(OBJS) $(TARGET)
 
 TEST_TARGET = chat_provider_tests
-TEST_OBJS = src/chat_provider.o src/config_loader.o tests/chat_provider_tests.o
+TEST_OBJS = src/chat_provider.o src/config_loader.o src/tts.o tests/chat_provider_tests.o tests/tts_tests.o
 
 $(TEST_TARGET): $(TEST_OBJS)
 	$(CXX) $(CXXFLAGS) -o $@ $(TEST_OBJS) -ljsoncpp -lcurl

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Environment overrides are also supported:
 - `AIMASTER_TTS_VOICE`
 - `AIMASTER_TTS_SPEAKER`
 
-Request payloads are sent as JSON with `text`, plus optional `voice` and `speaker` fields when configured. Response parsing accepts a base64 audio string from `audio`, `audio_base64`, or `wav_base64`.
+Request payloads are sent as JSON with `text`, `return_type=base64`, `format=wav`, and `response_format=wav`, plus optional `voice`, `speaker`, and `speaker_id` fields when configured. Response parsing accepts base64 audio from `audio`, `audio_base64`, `wav_base64`, `audio_data`, and nested `data.*` variants.
 
 ### Troubleshooting audio
 

--- a/README.md
+++ b/README.md
@@ -137,3 +137,59 @@ To switch to an OpenAI-compatible backend:
 Type `MODEL` to fetch available models from your configured upstream and interactively select one. The choice is persisted to `config.txt`.
 
 Execute `serial-passthru.bat` to pass the serial port from Windows to WSL, updating the batch file for your USB serial adapter IDs.
+
+## `/speak` text-to-speech
+
+AImaster now supports an additive local `/speak` command:
+
+- `/speak on` enables text-to-speech playback for the final assistant reply.
+- `/speak off` disables text-to-speech playback.
+- Normal console output is unchanged; speech is played in addition to the printed response.
+- `/speak` is handled locally and is never sent to the LLM as chat content.
+
+When speech is enabled, AImaster sends the final assistant text to the configured Quick-Piper-style HTTP endpoint, expects JSON containing base64 audio, decodes it, writes a temporary WAV file, and attempts playback using the first available backend in this order:
+
+1. `ffplay`
+2. `paplay`
+3. `aplay`
+
+If speech synthesis, decoding, or playback fails, AImaster logs a concise warning and continues without interrupting the normal text flow.
+
+### TTS configuration
+
+These config keys are supported in `config.txt` and `config-example.txt`:
+
+```ini
+# Text-to-speech (disabled by default)
+tts_enabled=false
+tts_endpoint_url=http://127.0.0.1:5000/tts
+tts_timeout_seconds=10
+#tts_voice=en-us
+#tts_speaker=narrator
+```
+
+Environment overrides are also supported:
+
+- `AIMASTER_TTS_ENABLED`
+- `AIMASTER_TTS_ENDPOINT`
+- `AIMASTER_TTS_TIMEOUT_SECONDS`
+- `AIMASTER_TTS_VOICE`
+- `AIMASTER_TTS_SPEAKER`
+
+Request payloads are sent as JSON with `text`, plus optional `voice` and `speaker` fields when configured. Response parsing accepts a base64 audio string from `audio`, `audio_base64`, or `wav_base64`.
+
+### Troubleshooting audio
+
+#### No audio heard
+
+- Confirm `/speak on` is enabled.
+- Confirm one of `ffplay`, `paplay`, or `aplay` is installed and available on `PATH`.
+- Check stderr for the selected playback backend or warning message.
+- Verify the endpoint returns playable WAV/base64 content.
+
+#### Endpoint connectivity
+
+- Verify `tts_endpoint_url` points to the running Quick-Piper endpoint.
+- Increase `tts_timeout_seconds` if synthesis is slow.
+- If needed, set `tts_voice` and `tts_speaker` to values accepted by your endpoint deployment.
+- If the endpoint is unavailable or returns invalid JSON, AImaster keeps the normal text reply and logs a warning instead of crashing.

--- a/README.md
+++ b/README.md
@@ -144,10 +144,11 @@ AImaster now supports an additive local `/speak` command:
 
 - `/speak on` enables text-to-speech playback for the final assistant reply.
 - `/speak off` disables text-to-speech playback.
+- `/voice corie`, `/voice semaine`, or `/voice southern_english_female` selects the TTS voice alias.
 - Normal console output is unchanged; speech is played in addition to the printed response.
 - `/speak` is handled locally and is never sent to the LLM as chat content.
 
-When speech is enabled, AImaster sends the final assistant text to the configured Quick-Piper-Endpoint `/speak` URL using the documented `play=0&return_audio=1` flow, prefers returned WAV audio bytes directly, and falls back to compatible JSON/base64 parsing if needed before attempting playback with the first available backend in this order:
+When speech is enabled, AImaster sends the final assistant text to the configured Quick-Piper-Endpoint `/speak` URL using the streamed base64 chunk flow `play=0&stream_audio_chunks=1`, decodes each `audio_b64_wav` NDJSON chunk, and plays the chunks in order before falling back to compatible raw WAV or JSON/base64 parsing when needed. Playback backends are tried in this order:
 
 1. `paplay`
 2. `aplay`
@@ -164,8 +165,8 @@ These config keys are supported in `config.txt` and `config-example.txt`:
 tts_enabled=false
 tts_endpoint_url=http://127.0.0.1:8092/speak
 tts_timeout_seconds=10
-#tts_voice=en-us
-#tts_speaker=narrator
+tts_voice=corie
+#tts_speaker=0
 ```
 
 Environment overrides are also supported:
@@ -176,7 +177,7 @@ Environment overrides are also supported:
 - `AIMASTER_TTS_VOICE`
 - `AIMASTER_TTS_SPEAKER`
 
-Request payloads follow the upstream examples by sending `text` (and `prompt` as a compatibility alias), plus optional `voice` and `speaker` values in the JSON body. The client appends `play=0&return_audio=1` to the configured `/speak` URL so the shim returns WAV audio bytes directly; for resilience it also accepts compatible JSON/base64 fields such as `audio`, `audio_base64`, `wav_base64`, `audio_data`, and nested `data.*` variants.
+Request payloads follow the upstream examples by sending `text` (and `prompt` as a compatibility alias), plus optional `voice` and `speaker` values in the JSON body. The client now prioritizes the upstream NDJSON stream example by appending `play=0&stream_audio_chunks=1` to the configured `/speak` URL and decoding each `audio_b64_wav` chunk. For resilience it still accepts direct WAV responses and compatible JSON/base64 fields such as `audio`, `audio_base64`, `wav_base64`, `audio_data`, and nested `data.*` variants.
 
 ### Troubleshooting audio
 
@@ -191,5 +192,5 @@ Request payloads follow the upstream examples by sending `text` (and `prompt` as
 
 - Verify `tts_endpoint_url` points to the running Quick-Piper endpoint.
 - Increase `tts_timeout_seconds` if synthesis is slow.
-- If needed, set `tts_voice` and `tts_speaker` to values accepted by your endpoint deployment.
+- Use `/voice corie`, `/voice semaine`, or `/voice southern_english_female` to switch aliases quickly, or set `tts_voice` directly in config.
 - If the endpoint is unavailable or returns invalid JSON, AImaster keeps the normal text reply and logs a warning instead of crashing.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ AImaster now supports an additive local `/speak` command:
 - Normal console output is unchanged; speech is played in addition to the printed response.
 - `/speak` is handled locally and is never sent to the LLM as chat content.
 
-When speech is enabled, AImaster sends the final assistant text to the configured Quick-Piper-style HTTP endpoint, expects JSON containing base64 audio, decodes it, writes a temporary WAV file, and attempts playback using the first available backend in this order:
+When speech is enabled, AImaster sends the final assistant text to the configured Quick-Piper-Endpoint `/speak` URL using the documented `play=0&return_audio=1` flow, prefers returned WAV audio bytes directly, and falls back to compatible JSON/base64 parsing if needed before attempting playback with the first available backend in this order:
 
 1. `ffplay`
 2. `paplay`
@@ -162,7 +162,7 @@ These config keys are supported in `config.txt` and `config-example.txt`:
 ```ini
 # Text-to-speech (disabled by default)
 tts_enabled=false
-tts_endpoint_url=http://127.0.0.1:5000/tts
+tts_endpoint_url=http://127.0.0.1:8092/speak
 tts_timeout_seconds=10
 #tts_voice=en-us
 #tts_speaker=narrator
@@ -176,7 +176,7 @@ Environment overrides are also supported:
 - `AIMASTER_TTS_VOICE`
 - `AIMASTER_TTS_SPEAKER`
 
-Request payloads are sent as JSON with `text`, `return_type=base64`, `format=wav`, and `response_format=wav`, plus optional `voice`, `speaker`, and `speaker_id` fields when configured. Response parsing accepts base64 audio from `audio`, `audio_base64`, `wav_base64`, `audio_data`, and nested `data.*` variants.
+Request payloads follow the upstream examples by sending `text` (and `prompt` as a compatibility alias), plus optional `voice` and `speaker` values in the JSON body. The client appends `play=0&return_audio=1` to the configured `/speak` URL so the shim returns WAV audio bytes directly; for resilience it also accepts compatible JSON/base64 fields such as `audio`, `audio_base64`, `wav_base64`, `audio_data`, and nested `data.*` variants.
 
 ### Troubleshooting audio
 

--- a/README.md
+++ b/README.md
@@ -144,11 +144,10 @@ AImaster now supports an additive local `/speak` command:
 
 - `/speak on` enables text-to-speech playback for the final assistant reply.
 - `/speak off` disables text-to-speech playback.
-- `/voice corie`, `/voice semaine`, or `/voice southern_english_female` selects the TTS voice alias.
 - Normal console output is unchanged; speech is played in addition to the printed response.
 - `/speak` is handled locally and is never sent to the LLM as chat content.
 
-When speech is enabled, AImaster sends the final assistant text to the configured Quick-Piper-Endpoint `/speak` URL using the streamed base64 chunk flow `play=0&stream_audio_chunks=1`, decodes each `audio_b64_wav` NDJSON chunk, and plays the chunks in order before falling back to compatible raw WAV or JSON/base64 parsing when needed. Playback backends are tried in this order:
+When speech is enabled, AImaster sends the final assistant text to the configured Quick-Piper-Endpoint `/speak` URL using the documented `play=0&return_audio=1` flow, prefers returned WAV audio bytes directly, and falls back to compatible JSON/base64 parsing if needed before attempting playback with the first available backend in this order:
 
 1. `paplay`
 2. `aplay`
@@ -165,8 +164,8 @@ These config keys are supported in `config.txt` and `config-example.txt`:
 tts_enabled=false
 tts_endpoint_url=http://127.0.0.1:8092/speak
 tts_timeout_seconds=10
-tts_voice=corie
-#tts_speaker=0
+#tts_voice=en-us
+#tts_speaker=narrator
 ```
 
 Environment overrides are also supported:
@@ -177,7 +176,7 @@ Environment overrides are also supported:
 - `AIMASTER_TTS_VOICE`
 - `AIMASTER_TTS_SPEAKER`
 
-Request payloads follow the upstream examples by sending `text` (and `prompt` as a compatibility alias), plus optional `voice` and `speaker` values in the JSON body. The client now prioritizes the upstream NDJSON stream example by appending `play=0&stream_audio_chunks=1` to the configured `/speak` URL and decoding each `audio_b64_wav` chunk. For resilience it still accepts direct WAV responses and compatible JSON/base64 fields such as `audio`, `audio_base64`, `wav_base64`, `audio_data`, and nested `data.*` variants.
+Request payloads follow the upstream examples by sending `text` (and `prompt` as a compatibility alias), plus optional `voice` and `speaker` values in the JSON body. The client appends `play=0&return_audio=1` to the configured `/speak` URL so the shim returns WAV audio bytes directly; for resilience it also accepts compatible JSON/base64 fields such as `audio`, `audio_base64`, `wav_base64`, `audio_data`, and nested `data.*` variants.
 
 ### Troubleshooting audio
 
@@ -192,5 +191,5 @@ Request payloads follow the upstream examples by sending `text` (and `prompt` as
 
 - Verify `tts_endpoint_url` points to the running Quick-Piper endpoint.
 - Increase `tts_timeout_seconds` if synthesis is slow.
-- Use `/voice corie`, `/voice semaine`, or `/voice southern_english_female` to switch aliases quickly, or set `tts_voice` directly in config.
+- If needed, set `tts_voice` and `tts_speaker` to values accepted by your endpoint deployment.
 - If the endpoint is unavailable or returns invalid JSON, AImaster keeps the normal text reply and logs a warning instead of crashing.

--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ AImaster now supports an additive local `/speak` command:
 
 When speech is enabled, AImaster sends the final assistant text to the configured Quick-Piper-Endpoint `/speak` URL using the documented `play=0&return_audio=1` flow, prefers returned WAV audio bytes directly, and falls back to compatible JSON/base64 parsing if needed before attempting playback with the first available backend in this order:
 
-1. `ffplay`
-2. `paplay`
-3. `aplay`
+1. `paplay`
+2. `aplay`
+3. `ffplay`
 
 If speech synthesis, decoding, or playback fails, AImaster logs a concise warning and continues without interrupting the normal text flow.
 
@@ -183,7 +183,7 @@ Request payloads follow the upstream examples by sending `text` (and `prompt` as
 #### No audio heard
 
 - Confirm `/speak on` is enabled.
-- Confirm one of `ffplay`, `paplay`, or `aplay` is installed and available on `PATH`.
+- Confirm one of `paplay`, `aplay`, or `ffplay` is installed and available on `PATH`.
 - Check stderr for the selected playback backend or warning message.
 - Verify the endpoint returns playable WAV/base64 content.
 

--- a/cmds.csv
+++ b/cmds.csv
@@ -11,3 +11,4 @@ RAG_SESSION,Display the session information.
 DELAY,Set the Chars per second (CPS) delay for responses.
  /speak on,Enable text-to-speech output for assistant replies.
 /speak off,Disable text-to-speech output.
+/voice corie|semaine|southern_english_female,Select the TTS voice alias.

--- a/cmds.csv
+++ b/cmds.csv
@@ -9,4 +9,5 @@ RAG_INGEST,Ingest a folder into the RAG system.
 RAG_SHOW,Show the contents of the RAG ingestion.
 RAG_SESSION,Display the session information.
 DELAY,Set the Chars per second (CPS) delay for responses.
- 
+ /speak on,Enable text-to-speech output for assistant replies.
+/speak off,Disable text-to-speech output.

--- a/cmds.csv
+++ b/cmds.csv
@@ -11,4 +11,3 @@ RAG_SESSION,Display the session information.
 DELAY,Set the Chars per second (CPS) delay for responses.
  /speak on,Enable text-to-speech output for assistant replies.
 /speak off,Disable text-to-speech output.
-/voice corie|semaine|southern_english_female,Select the TTS voice alias.

--- a/config-example.txt
+++ b/config-example.txt
@@ -28,5 +28,5 @@ commands_csv=cmds.csv
 tts_enabled=false
 tts_endpoint_url=http://127.0.0.1:8092/speak
 tts_timeout_seconds=10
-tts_voice=corie
+#tts_voice=en-us
 #tts_speaker=narrator

--- a/config-example.txt
+++ b/config-example.txt
@@ -23,3 +23,10 @@ extra_header=X-Client: AImaster
 rag_chunks=25
 rag_threshold=0.2
 commands_csv=cmds.csv
+
+# Text-to-speech (disabled by default)
+tts_enabled=false
+tts_endpoint_url=http://127.0.0.1:5000/tts
+tts_timeout_seconds=10
+#tts_voice=en-us
+#tts_speaker=narrator

--- a/config-example.txt
+++ b/config-example.txt
@@ -28,5 +28,5 @@ commands_csv=cmds.csv
 tts_enabled=false
 tts_endpoint_url=http://127.0.0.1:8092/speak
 tts_timeout_seconds=10
-#tts_voice=en-us
+tts_voice=corie
 #tts_speaker=narrator

--- a/config-example.txt
+++ b/config-example.txt
@@ -26,7 +26,7 @@ commands_csv=cmds.csv
 
 # Text-to-speech (disabled by default)
 tts_enabled=false
-tts_endpoint_url=http://127.0.0.1:5000/tts
+tts_endpoint_url=http://127.0.0.1:8092/speak
 tts_timeout_seconds=10
 #tts_voice=en-us
 #tts_speaker=narrator

--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -33,6 +33,13 @@ struct AppConfig {
     Json::Value tools;
     Json::Value tool_choice;
 
+    // Text-to-speech
+    bool tts_enabled = false;
+    std::string tts_endpoint_url = "http://127.0.0.1:5000/tts";
+    long tts_timeout_seconds = 10;
+    std::string tts_voice;
+    std::string tts_speaker;
+
     // RAG retrieval defaults (used by ASK/INT when RAG is active)
     int rag_chunks = 25;
     double rag_threshold = 0.2;

--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -35,7 +35,7 @@ struct AppConfig {
 
     // Text-to-speech
     bool tts_enabled = false;
-    std::string tts_endpoint_url = "http://127.0.0.1:5000/tts";
+    std::string tts_endpoint_url = "http://127.0.0.1:8092/speak";
     long tts_timeout_seconds = 10;
     std::string tts_voice;
     std::string tts_speaker;

--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -37,7 +37,7 @@ struct AppConfig {
     bool tts_enabled = false;
     std::string tts_endpoint_url = "http://127.0.0.1:8092/speak";
     long tts_timeout_seconds = 10;
-    std::string tts_voice;
+    std::string tts_voice = "corie";
     std::string tts_speaker;
 
     // RAG retrieval defaults (used by ASK/INT when RAG is active)

--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -37,7 +37,7 @@ struct AppConfig {
     bool tts_enabled = false;
     std::string tts_endpoint_url = "http://127.0.0.1:8092/speak";
     long tts_timeout_seconds = 10;
-    std::string tts_voice = "corie";
+    std::string tts_voice;
     std::string tts_speaker;
 
     // RAG retrieval defaults (used by ASK/INT when RAG is active)

--- a/include/tts.hpp
+++ b/include/tts.hpp
@@ -17,17 +17,8 @@ struct TTSResponseAudio {
     std::string content_type;
 };
 
-struct VoiceCommandResult {
-    bool recognized = false;
-    bool valid = false;
-    std::string voice;
-    std::string message;
-};
-
 SpeakCommandResult parseSpeakCommand(const std::string& command);
-VoiceCommandResult parseVoiceCommand(const std::string& command);
 bool applySpeakCommand(const std::string& command, AppConfig& config, SpeakCommandResult& out);
-bool applyVoiceCommand(const std::string& command, AppConfig& config, VoiceCommandResult& out);
 Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& config);
 std::string buildTTSRequestUrl(const AppConfig& config);
 bool decodeBase64AudioResponse(const std::string& response_body,

--- a/include/tts.hpp
+++ b/include/tts.hpp
@@ -20,6 +20,7 @@ struct TTSResponseAudio {
 SpeakCommandResult parseSpeakCommand(const std::string& command);
 bool applySpeakCommand(const std::string& command, AppConfig& config, SpeakCommandResult& out);
 Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& config);
+std::string buildTTSRequestUrl(const AppConfig& config);
 bool decodeBase64AudioResponse(const std::string& response_body,
                                TTSResponseAudio& out,
                                std::string& error);

--- a/include/tts.hpp
+++ b/include/tts.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "config_loader.h"
+
+#include <json/json.h>
+#include <string>
+#include <vector>
+
+struct SpeakCommandResult {
+    bool recognized = false;
+    bool enable = false;
+    std::string message;
+};
+
+struct TTSResponseAudio {
+    std::vector<unsigned char> audio_bytes;
+    std::string content_type;
+};
+
+SpeakCommandResult parseSpeakCommand(const std::string& command);
+bool applySpeakCommand(const std::string& command, AppConfig& config, SpeakCommandResult& out);
+Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& config);
+bool decodeBase64AudioResponse(const std::string& response_body,
+                               TTSResponseAudio& out,
+                               std::string& error);
+
+bool maybeSpeakText(const std::string& text, const AppConfig& config);

--- a/include/tts.hpp
+++ b/include/tts.hpp
@@ -17,8 +17,17 @@ struct TTSResponseAudio {
     std::string content_type;
 };
 
+struct VoiceCommandResult {
+    bool recognized = false;
+    bool valid = false;
+    std::string voice;
+    std::string message;
+};
+
 SpeakCommandResult parseSpeakCommand(const std::string& command);
+VoiceCommandResult parseVoiceCommand(const std::string& command);
 bool applySpeakCommand(const std::string& command, AppConfig& config, SpeakCommandResult& out);
+bool applyVoiceCommand(const std::string& command, AppConfig& config, VoiceCommandResult& out);
 Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& config);
 std::string buildTTSRequestUrl(const AppConfig& config);
 bool decodeBase64AudioResponse(const std::string& response_body,

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -6,6 +6,7 @@
 #include <cctype>
 #include <iostream>
 #include <vector>
+#include <cstdlib>
 
 static inline void rtrim(std::string& s) { while (!s.empty() && std::isspace((unsigned char)s.back())) s.pop_back(); }
 static inline void ltrim(std::string& s) { size_t i=0; while (i<s.size() && std::isspace((unsigned char)s[i])) ++i; if (i) s.erase(0,i); }
@@ -22,6 +23,14 @@ static bool parse_long(const std::string& s, long& out) {
 static bool parse_double(const std::string& s, double& out) {
     try { size_t idx=0; double v=std::stod(s,&idx); if (idx!=s.size()) return false; out=v; return true; }
     catch(...) { return false; }
+}
+
+static bool parse_bool(const std::string& s, bool& out) {
+    std::string v = s;
+    std::transform(v.begin(), v.end(), v.begin(), [](unsigned char c){ return std::tolower(c); });
+    if (v=="1" || v=="true" || v=="yes" || v=="on") { out=true; return true; }
+    if (v=="0" || v=="false" || v=="no" || v=="off") { out=false; return true; }
+    return false;
 }
 
 static void parse_extra_header(const std::string& input, std::map<std::string,std::string>& out) {
@@ -87,6 +96,11 @@ bool loadConfig(const std::string& path, AppConfig& out) {
         else if (key == "temperature") { double v; if (parse_double(val, v)) out.temperature = v; }
         else if (key == "num_predict") { int v; if (parse_int(val, v) && v>0) out.num_predict = v; }
         else if (key == "format") out.format = val;
+        else if (key == "tts_endpoint_url") out.tts_endpoint_url = val;
+        else if (key == "tts_timeout_seconds") { long v; if (parse_long(val, v) && v > 0) out.tts_timeout_seconds = v; }
+        else if (key == "tts_voice") out.tts_voice = val;
+        else if (key == "tts_speaker") out.tts_speaker = val;
+        else if (key == "tts_enabled") { bool v; if (parse_bool(val, v)) out.tts_enabled = v; }
         else if (key == "extra_header") parse_extra_header(val, out.extra_headers);
         else if (key == "rag_chunks") { int v; if (parse_int(val, v) && v > 0) out.rag_chunks = v; }
         else if (key == "rag_threshold") { double v; if (parse_double(val, v) && v >= 0.0) out.rag_threshold = v; }
@@ -101,6 +115,12 @@ bool loadConfig(const std::string& path, AppConfig& out) {
 
         else { /* ignore unknown */ }
     }
+
+    if (const char* env = std::getenv("AIMASTER_TTS_ENABLED")) { bool v; if (parse_bool(env, v)) out.tts_enabled = v; }
+    if (const char* env = std::getenv("AIMASTER_TTS_ENDPOINT")) out.tts_endpoint_url = env;
+    if (const char* env = std::getenv("AIMASTER_TTS_TIMEOUT_SECONDS")) { long v; if (parse_long(env, v) && v > 0) out.tts_timeout_seconds = v; }
+    if (const char* env = std::getenv("AIMASTER_TTS_VOICE")) out.tts_voice = env;
+    if (const char* env = std::getenv("AIMASTER_TTS_SPEAKER")) out.tts_speaker = env;
 
     return true;
 }
@@ -127,6 +147,11 @@ bool saveConfig(const std::string& path, const AppConfig& cfg) {
     if (cfg.temperature >= 0.0) out << "temperature=" << cfg.temperature << "\n";
     if (cfg.num_predict > 0) out << "num_predict=" << cfg.num_predict << "\n";
     if (!cfg.format.empty()) out << "format=" << cfg.format << "\n";
+    out << "tts_enabled=" << (cfg.tts_enabled ? "true" : "false") << "\n";
+    out << "tts_endpoint_url=" << cfg.tts_endpoint_url << "\n";
+    out << "tts_timeout_seconds=" << cfg.tts_timeout_seconds << "\n";
+    if (!cfg.tts_voice.empty()) out << "tts_voice=" << cfg.tts_voice << "\n";
+    if (!cfg.tts_speaker.empty()) out << "tts_speaker=" << cfg.tts_speaker << "\n";
     for (const auto& kv : cfg.extra_headers) out << "extra_header=" << kv.first << ": " << kv.second << "\n";
     out << "rag_chunks=" << cfg.rag_chunks << "\n";
     out << "rag_threshold=" << cfg.rag_threshold << "\n";

--- a/src/ollama_client.cpp
+++ b/src/ollama_client.cpp
@@ -6,6 +6,7 @@
 #include "rag_int_bridge.hpp"
 #include "utils.h"
 #include "chat_provider.hpp"
+#include "tts.hpp"
 
 #include <curl/curl.h>
 #include <algorithm>
@@ -74,14 +75,6 @@ static size_t ocurl_write_to_string(void* contents, size_t size, size_t nmemb, v
     s->append((char*)contents, total);
     return total;
 }
-<<<<<<< HEAD
-static std::string oderive_tags_endpoint(const std::string& chat_url) {
-    auto pos = chat_url.find("/api/");
-    if (pos == std::string::npos) return chat_url;
-    return chat_url.substr(0, pos) + "/api/tags";
-}
-=======
->>>>>>> codex/add-openai-compatibility-adapter-to-aimaster-jt0i1p
 static std::vector<std::string> fetch_provider_models(const AppConfig& config, std::string& error) {
     std::vector<std::string> models;
     std::string url = deriveModelsUrl(config);
@@ -192,63 +185,6 @@ namespace {
     }
 }
 
-<<<<<<< HEAD
-static size_t StreamCallback(void* contents, size_t size, size_t nmemb, void* userp) {
-    size_t totalSize = size * nmemb;
-    std::string chunk((char*)contents, totalSize);
-
-    if (diagMode) {
-        std::cerr << "\n[DIAG CHUNK] " << chunk << std::endl;
-    }
-
-    StreamData* data = (StreamData*)userp;
-    if (!data->first_chunk_received) {
-        data->first_chunk_received = true;
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::high_resolution_clock::now() - data->start_time
-        ).count();
-        route_output(std::string("[Response ") + std::to_string(elapsed) + "ms]", true);
-    }
-    data->raw_output += chunk;
-
-    Json::CharReaderBuilder reader;
-    Json::Value parsed;
-    std::string errs;
-    std::istringstream ss(chunk);
-
-    if (Json::parseFromStream(reader, ss, &parsed, &errs)) {
-        if (parsed.isObject() &&
-            parsed.isMember("message") &&
-            parsed["message"].isObject() &&
-            parsed["message"].isMember("content")) {
-
-            std::string text = parsed["message"]["content"].asString();
-            route_output(text);
-
-            if (!serial_available) {
-                std::ofstream log("log.txt", std::ios::app);
-                if (log.is_open()) {
-                    log << text;
-                    log.flush();
-                }
-            }
-            data->collected += text;
-        }
-    }
-    return totalSize;
-}
-
-static void setCurlStreamingOptions(CURL* curl, struct curl_slist*& headers) {
-    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
-    curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 1L);
-    headers = curl_slist_append(headers, "Content-Type: application/json");
-    headers = curl_slist_append(headers, "Expect:");
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, StreamCallback);
-}
-
-=======
->>>>>>> codex/add-openai-compatibility-adapter-to-aimaster-jt0i1p
 // ---- Send message to configured provider ----
 static bool sendMessageToOllama(const std::string& query,
                                 std::vector<Json::Value>& chatHistory,
@@ -308,6 +244,7 @@ static bool sendMessageToOllama(const std::string& query,
     if (!providerResult.usage.isNull()) reply["usage"] = providerResult.usage;
     chatHistory.push_back(reply);
     saveCodeBlocks(providerResult.assistant_content);
+    maybeSpeakText(providerResult.assistant_content, config);
     return true;
 }
 
@@ -359,10 +296,23 @@ void SerialINT_HandleLine(const std::string& line, AppConfig& config) {
         route_output(modelPrompt(config, "> "), false);
         return;
     }
-        if (line == "/n") {
+    if (line == "/n") {
         g_serial_int_active.store(false, std::memory_order_relaxed);
         route_output(modelPrompt(config, "> "), false);
+        return;
     }
+
+    SpeakCommandResult speak;
+    if (applySpeakCommand(line, config, speak)) {
+        const std::string upper = toupper_copy(line);
+        if (upper == "/SPEAK ON" || upper == "/SPEAK OFF") {
+            if (saveConfig("config.txt", config)) speak.message += " (saved)";
+        }
+        route_output(speak.message, true);
+        route_output("-> ", false);
+        return;
+    }
+
     // Try RAG first (if active and enabled)
     std::string rag_answer;
     if (rag_int::TryRAGAnswer(line, rag_answer, /*k=*/config.rag_chunks, /*threshold=*/config.rag_threshold)) {
@@ -410,6 +360,20 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         return ragOut; // handled RAG_INGEST / RAG_ASK / RAG_SESSION / etc
     }
 
+    Json::Value result;
+    const std::string cmd_upper = toupper_copy(command);
+
+    SpeakCommandResult speak;
+    if (applySpeakCommand(command, config, speak)) {
+        if (cmd_upper == "/SPEAK ON" || cmd_upper == "/SPEAK OFF") {
+            if (saveConfig("config.txt", config)) speak.message += " (saved)";
+        }
+        route_output(speak.message, true);
+        result["status"] = (cmd_upper == "/SPEAK ON" || cmd_upper == "/SPEAK OFF") ? "success" : "error";
+        result["tts_enabled"] = config.tts_enabled;
+        return result;
+    }
+
     // One-time Ollama connectivity status on first command
     if (!g_oc_ping_done) {
         g_oc_ping_done = true;
@@ -424,9 +388,6 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
     }
 
     static std::vector<Json::Value> chatHistory;
-    Json::Value result;
-
-    const std::string cmd_upper = toupper_copy(command);
 
     // ===== ASK =====
     if (cmd_upper == "ASK" || cmd_upper.rfind("ASK ", 0) == 0) {
@@ -513,6 +474,11 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         result["ollama_timeout_seconds"] = Json::Value(static_cast<Json::UInt64>(config.ollama_timeout_seconds));
         result["rag_chunks"] = config.rag_chunks;
         result["rag_threshold"] = config.rag_threshold;
+        result["tts_enabled"] = config.tts_enabled;
+        result["tts_endpoint_url"] = config.tts_endpoint_url;
+        result["tts_timeout_seconds"] = Json::Value(static_cast<Json::UInt64>(config.tts_timeout_seconds));
+        result["tts_voice"] = config.tts_voice;
+        result["tts_speaker"] = config.tts_speaker;
         route_output("Current configuration:", true);
         route_output(std::string("\tSerial port: ") + config.serial_port, true);
         route_output(std::string("\tBaudrate: ") + std::to_string(config.baudrate), true);
@@ -564,6 +530,8 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
             cmds["INT"] = "Enter interactive mode with the model.";
             cmds["READ"] = "Send a file with context to the model.";
             cmds["RESET"] = "Clear chat history.";
+            cmds["/speak on"] = "Enable text-to-speech output for assistant replies.";
+            cmds["/speak off"] = "Disable text-to-speech output.";
             cmds["CFG"] = "Show current configuration.";
             cmds["HELP"] = "List available commands.";
             cmds["MODEL"] = "List or set Ollama model.";

--- a/src/ollama_client.cpp
+++ b/src/ollama_client.cpp
@@ -313,13 +313,6 @@ void SerialINT_HandleLine(const std::string& line, AppConfig& config) {
         return;
     }
 
-    VoiceCommandResult voice;
-    if (applyVoiceCommand(line, config, voice)) {
-        if (voice.valid && saveConfig("config.txt", config)) voice.message += " (saved)";
-        route_output(voice.message, true);
-        route_output("-> ", false);
-        return;
-    }
 
     // Try RAG first (if active and enabled)
     std::string rag_answer;
@@ -382,14 +375,6 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         return result;
     }
 
-    VoiceCommandResult voice;
-    if (applyVoiceCommand(command, config, voice)) {
-        if (voice.valid && saveConfig("config.txt", config)) voice.message += " (saved)";
-        route_output(voice.message, true);
-        result["status"] = voice.valid ? "success" : "error";
-        result["tts_voice"] = config.tts_voice;
-        return result;
-    }
 
     // One-time Ollama connectivity status on first command
     if (!g_oc_ping_done) {
@@ -549,7 +534,6 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
             cmds["RESET"] = "Clear chat history.";
             cmds["/speak on"] = "Enable text-to-speech output for assistant replies.";
             cmds["/speak off"] = "Disable text-to-speech output.";
-            cmds["/voice corie|semaine|southern_english_female"] = "Select the TTS voice alias.";
             cmds["CFG"] = "Show current configuration.";
             cmds["HELP"] = "List available commands.";
             cmds["MODEL"] = "List or set Ollama model.";

--- a/src/ollama_client.cpp
+++ b/src/ollama_client.cpp
@@ -313,6 +313,14 @@ void SerialINT_HandleLine(const std::string& line, AppConfig& config) {
         return;
     }
 
+    VoiceCommandResult voice;
+    if (applyVoiceCommand(line, config, voice)) {
+        if (voice.valid && saveConfig("config.txt", config)) voice.message += " (saved)";
+        route_output(voice.message, true);
+        route_output("-> ", false);
+        return;
+    }
+
     // Try RAG first (if active and enabled)
     std::string rag_answer;
     if (rag_int::TryRAGAnswer(line, rag_answer, /*k=*/config.rag_chunks, /*threshold=*/config.rag_threshold)) {
@@ -371,6 +379,15 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         route_output(speak.message, true);
         result["status"] = (cmd_upper == "/SPEAK ON" || cmd_upper == "/SPEAK OFF") ? "success" : "error";
         result["tts_enabled"] = config.tts_enabled;
+        return result;
+    }
+
+    VoiceCommandResult voice;
+    if (applyVoiceCommand(command, config, voice)) {
+        if (voice.valid && saveConfig("config.txt", config)) voice.message += " (saved)";
+        route_output(voice.message, true);
+        result["status"] = voice.valid ? "success" : "error";
+        result["tts_voice"] = config.tts_voice;
         return result;
     }
 
@@ -532,6 +549,7 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
             cmds["RESET"] = "Clear chat history.";
             cmds["/speak on"] = "Enable text-to-speech output for assistant replies.";
             cmds["/speak off"] = "Disable text-to-speech output.";
+            cmds["/voice corie|semaine|southern_english_female"] = "Select the TTS voice alias.";
             cmds["CFG"] = "Show current configuration.";
             cmds["HELP"] = "List available commands.";
             cmds["MODEL"] = "List or set Ollama model.";

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -31,6 +31,10 @@ std::string uppercase_copy(std::string s) {
     return s;
 }
 
+bool isSupportedVoice(const std::string& voice) {
+    return voice == "corie" || voice == "semaine" || voice == "southern_english_female";
+}
+
 std::string appendQueryParam(const std::string& url, const std::string& key, const std::string& value) {
     return url + (url.find('?') == std::string::npos ? "?" : "&") + key + "=" + value;
 }
@@ -230,6 +234,36 @@ bool applySpeakCommand(const std::string& command, AppConfig& config, SpeakComma
     return true;
 }
 
+
+VoiceCommandResult parseVoiceCommand(const std::string& command) {
+    VoiceCommandResult out;
+    std::string trimmed = trim_copy(command);
+    std::string upper = uppercase_copy(trimmed);
+    if (upper.rfind("/VOICE", 0) != 0) return out;
+    out.recognized = true;
+
+    std::istringstream iss(trimmed);
+    std::string verb, arg;
+    iss >> verb >> arg;
+    if (arg.empty()) {
+        out.message = "Usage: /voice corie|semaine|southern_english_female";
+        return out;
+    }
+    std::transform(arg.begin(), arg.end(), arg.begin(), [](unsigned char c){ return std::tolower(c); });
+    out.voice = arg;
+    out.valid = isSupportedVoice(arg);
+    if (out.valid) out.message = "[OK] Voice set to: " + arg;
+    else out.message = "Usage: /voice corie|semaine|southern_english_female";
+    return out;
+}
+
+bool applyVoiceCommand(const std::string& command, AppConfig& config, VoiceCommandResult& out) {
+    out = parseVoiceCommand(command);
+    if (!out.recognized) return false;
+    if (out.valid) config.tts_voice = out.voice;
+    return true;
+}
+
 Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& config) {
     Json::Value payload(Json::objectValue);
     payload["text"] = text;
@@ -247,7 +281,7 @@ Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& con
 std::string buildTTSRequestUrl(const AppConfig& config) {
     std::string url = config.tts_endpoint_url;
     url = appendQueryParam(url, "play", "0");
-    url = appendQueryParam(url, "return_audio", "1");
+    url = appendQueryParam(url, "stream_audio_chunks", "1");
     return url;
 }
 
@@ -286,6 +320,51 @@ bool decodeBase64AudioResponse(const std::string& response_body,
     }
     out.content_type = root.get("content_type", root.get("mime_type", "audio/wav")).asString();
     return decodeBase64(encoded, out.audio_bytes, error);
+}
+
+
+bool parseStreamedAudioChunks(const std::string& response_body,
+                              std::vector<std::vector<unsigned char>>& chunks,
+                              std::string& error) {
+    std::istringstream lines(response_body);
+    std::string line;
+    bool saw_done = false;
+    while (std::getline(lines, line)) {
+        line = trim_copy(line);
+        if (line.empty()) continue;
+
+        Json::CharReaderBuilder reader;
+        Json::Value root;
+        std::string errs;
+        std::istringstream ss(line);
+        if (!Json::parseFromStream(reader, ss, &root, &errs)) {
+            error = "invalid streamed JSON";
+            return false;
+        }
+
+        const std::string type = root.get("type", "").asString();
+        if (type == "audio_chunk") {
+            std::string encoded = root.get("audio_b64_wav", "").asString();
+            if (encoded.empty()) {
+                error = "missing audio_b64_wav field";
+                return false;
+            }
+            std::vector<unsigned char> bytes;
+            if (!decodeBase64(encoded, bytes, error)) return false;
+            chunks.push_back(std::move(bytes));
+        } else if (type == "error") {
+            error = root.get("detail", "stream error").asString();
+            return false;
+        } else if (type == "done") {
+            saw_done = true;
+        }
+    }
+
+    if (chunks.empty()) {
+        error = saw_done ? "no audio chunks returned" : "missing audio chunks";
+        return false;
+    }
+    return true;
 }
 
 bool maybeSpeakText(const std::string& text, const AppConfig& config) {
@@ -332,21 +411,31 @@ bool maybeSpeakText(const std::string& text, const AppConfig& config) {
         return false;
     }
 
-    TTSResponseAudio audio;
     std::string error;
     const bool looks_like_wav = response.size() >= 12 && response.compare(0, 4, "RIFF") == 0 && response.compare(8, 4, "WAVE") == 0;
-    if (content_type.rfind("audio/", 0) == 0 || content_type == "application/octet-stream" || looks_like_wav) {
-        audio.content_type = content_type.empty() ? "audio/wav" : content_type;
-        audio.audio_bytes.assign(response.begin(), response.end());
-    } else if (!decodeBase64AudioResponse(response, audio, error)) {
-        std::cerr << "[Warn] TTS response invalid: " << error << "\n";
-        return false;
+    std::vector<std::vector<unsigned char>> audio_chunks;
+    if (content_type == "application/x-ndjson" || response.find(""audio_b64_wav"") != std::string::npos) {
+        if (!parseStreamedAudioChunks(response, audio_chunks, error)) {
+            std::cerr << "[Warn] TTS response invalid: " << error << "\n";
+            return false;
+        }
+    } else if (content_type.rfind("audio/", 0) == 0 || content_type == "application/octet-stream" || looks_like_wav) {
+        audio_chunks.push_back(std::vector<unsigned char>(response.begin(), response.end()));
+    } else {
+        TTSResponseAudio audio;
+        if (!decodeBase64AudioResponse(response, audio, error)) {
+            std::cerr << "[Warn] TTS response invalid: " << error << "\n";
+            return false;
+        }
+        audio_chunks.push_back(std::move(audio.audio_bytes));
     }
 
     std::string backend_used;
-    if (!playAudioBytes(audio.audio_bytes, backend_used, error)) {
-        std::cerr << "[Warn] TTS playback failed: " << error << "\n";
-        return false;
+    for (const auto& chunk : audio_chunks) {
+        if (!playAudioBytes(chunk, backend_used, error)) {
+            std::cerr << "[Warn] TTS playback failed: " << error << "\n";
+            return false;
+        }
     }
 
     std::cerr << "[Info] TTS playback backend: " << backend_used << "\n";

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -229,8 +229,16 @@ bool applySpeakCommand(const std::string& command, AppConfig& config, SpeakComma
 Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& config) {
     Json::Value payload(Json::objectValue);
     payload["text"] = text;
-    if (!config.tts_voice.empty()) payload["voice"] = config.tts_voice;
-    if (!config.tts_speaker.empty()) payload["speaker"] = config.tts_speaker;
+    payload["return_type"] = "base64";
+    payload["format"] = "wav";
+    payload["response_format"] = "wav";
+    if (!config.tts_voice.empty()) {
+        payload["voice"] = config.tts_voice;
+    }
+    if (!config.tts_speaker.empty()) {
+        payload["speaker"] = config.tts_speaker;
+        payload["speaker_id"] = config.tts_speaker;
+    }
     return payload;
 }
 
@@ -245,19 +253,29 @@ bool decodeBase64AudioResponse(const std::string& response_body,
         error = "invalid JSON";
         return false;
     }
-    const char* fields[] = {"audio", "audio_base64", "wav_base64"};
-    std::string encoded;
-    for (const char* field : fields) {
-        if (root.isMember(field) && root[field].isString()) {
-            encoded = root[field].asString();
-            break;
+
+    auto extractAudio = [](const Json::Value& node) -> std::string {
+        const char* fields[] = {"audio", "audio_base64", "wav_base64", "audio_data", "data"};
+        for (const char* field : fields) {
+            if (!node.isObject() || !node.isMember(field)) continue;
+            const Json::Value& value = node[field];
+            if (std::string(field) != "data" && value.isString()) return value.asString();
+            if (value.isObject()) {
+                const char* nested_fields[] = {"audio", "audio_base64", "wav_base64", "audio_data"};
+                for (const char* nested : nested_fields) {
+                    if (value.isMember(nested) && value[nested].isString()) return value[nested].asString();
+                }
+            }
         }
-    }
+        return std::string();
+    };
+
+    std::string encoded = extractAudio(root);
     if (encoded.empty()) {
         error = "missing audio field";
         return false;
     }
-    out.content_type = root.get("content_type", "audio/wav").asString();
+    out.content_type = root.get("content_type", root.get("mime_type", "audio/wav")).asString();
     return decodeBase64(encoded, out.audio_bytes, error);
 }
 

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -171,13 +171,13 @@ bool playAudioBytes(const std::vector<unsigned char>& audio, std::string& backen
 
     std::vector<Backend> backends;
     std::string exe;
-    if (findExecutable("ffplay", exe)) backends.push_back({"ffplay", {exe, "-nodisp", "-autoexit", "-loglevel", "error", path}});
     if (findExecutable("paplay", exe)) backends.push_back({"paplay", {exe, path}});
-    if (findExecutable("aplay", exe)) backends.push_back({"aplay", {exe, path}});
+    if (findExecutable("aplay", exe)) backends.push_back({"aplay", {exe, "-q", path}});
+    if (findExecutable("ffplay", exe)) backends.push_back({"ffplay", {exe, "-nodisp", "-autoexit", "-loglevel", "error", path}});
 
     if (backends.empty()) {
         ::unlink(path.c_str());
-        error = "no playback backend found (tried ffplay, paplay, aplay)";
+        error = "no playback backend found (tried paplay, aplay, ffplay)";
         return false;
     }
 
@@ -334,7 +334,8 @@ bool maybeSpeakText(const std::string& text, const AppConfig& config) {
 
     TTSResponseAudio audio;
     std::string error;
-    if (content_type.rfind("audio/", 0) == 0 || content_type == "application/octet-stream") {
+    const bool looks_like_wav = response.size() >= 12 && response.compare(0, 4, "RIFF") == 0 && response.compare(8, 4, "WAVE") == 0;
+    if (content_type.rfind("audio/", 0) == 0 || content_type == "application/octet-stream" || looks_like_wav) {
         audio.content_type = content_type.empty() ? "audio/wav" : content_type;
         audio.audio_bytes.assign(response.begin(), response.end());
     } else if (!decodeBase64AudioResponse(response, audio, error)) {

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -31,6 +31,10 @@ std::string uppercase_copy(std::string s) {
     return s;
 }
 
+std::string appendQueryParam(const std::string& url, const std::string& key, const std::string& value) {
+    return url + (url.find('?') == std::string::npos ? "?" : "&") + key + "=" + value;
+}
+
 bool findExecutable(const std::string& name, std::string& out_path) {
     const char* path_env = std::getenv("PATH");
     if (!path_env) return false;
@@ -229,17 +233,22 @@ bool applySpeakCommand(const std::string& command, AppConfig& config, SpeakComma
 Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& config) {
     Json::Value payload(Json::objectValue);
     payload["text"] = text;
-    payload["return_type"] = "base64";
-    payload["format"] = "wav";
-    payload["response_format"] = "wav";
+    payload["prompt"] = text;
     if (!config.tts_voice.empty()) {
         payload["voice"] = config.tts_voice;
     }
     if (!config.tts_speaker.empty()) {
         payload["speaker"] = config.tts_speaker;
-        payload["speaker_id"] = config.tts_speaker;
     }
     return payload;
+}
+
+
+std::string buildTTSRequestUrl(const AppConfig& config) {
+    std::string url = config.tts_endpoint_url;
+    url = appendQueryParam(url, "play", "0");
+    url = appendQueryParam(url, "return_audio", "1");
+    return url;
 }
 
 bool decodeBase64AudioResponse(const std::string& response_body,
@@ -291,10 +300,11 @@ bool maybeSpeakText(const std::string& text, const AppConfig& config) {
 
     std::string response;
     std::string payload_str = Json::writeString(Json::StreamWriterBuilder(), buildTTSRequestPayload(text, config));
+    std::string request_url = buildTTSRequestUrl(config);
     struct curl_slist* headers = nullptr;
     headers = curl_slist_append(headers, "Content-Type: application/json");
 
-    curl_easy_setopt(curl, CURLOPT_URL, config.tts_endpoint_url.c_str());
+    curl_easy_setopt(curl, CURLOPT_URL, request_url.c_str());
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload_str.c_str());
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(payload_str.size()));
@@ -306,7 +316,10 @@ bool maybeSpeakText(const std::string& text, const AppConfig& config) {
 
     CURLcode res = curl_easy_perform(curl);
     long http_status = 0;
+    char* content_type_cstr = nullptr;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_status);
+    curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &content_type_cstr);
+    std::string content_type = content_type_cstr ? content_type_cstr : "";
     curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
 
@@ -321,7 +334,10 @@ bool maybeSpeakText(const std::string& text, const AppConfig& config) {
 
     TTSResponseAudio audio;
     std::string error;
-    if (!decodeBase64AudioResponse(response, audio, error)) {
+    if (content_type.rfind("audio/", 0) == 0 || content_type == "application/octet-stream") {
+        audio.content_type = content_type.empty() ? "audio/wav" : content_type;
+        audio.audio_bytes.assign(response.begin(), response.end());
+    } else if (!decodeBase64AudioResponse(response, audio, error)) {
         std::cerr << "[Warn] TTS response invalid: " << error << "\n";
         return false;
     }

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -31,9 +31,6 @@ std::string uppercase_copy(std::string s) {
     return s;
 }
 
-bool isSupportedVoice(const std::string& voice) {
-    return voice == "corie" || voice == "semaine" || voice == "southern_english_female";
-}
 
 std::string appendQueryParam(const std::string& url, const std::string& key, const std::string& value) {
     return url + (url.find('?') == std::string::npos ? "?" : "&") + key + "=" + value;
@@ -235,34 +232,6 @@ bool applySpeakCommand(const std::string& command, AppConfig& config, SpeakComma
 }
 
 
-VoiceCommandResult parseVoiceCommand(const std::string& command) {
-    VoiceCommandResult out;
-    std::string trimmed = trim_copy(command);
-    std::string upper = uppercase_copy(trimmed);
-    if (upper.rfind("/VOICE", 0) != 0) return out;
-    out.recognized = true;
-
-    std::istringstream iss(trimmed);
-    std::string verb, arg;
-    iss >> verb >> arg;
-    if (arg.empty()) {
-        out.message = "Usage: /voice corie|semaine|southern_english_female";
-        return out;
-    }
-    std::transform(arg.begin(), arg.end(), arg.begin(), [](unsigned char c){ return std::tolower(c); });
-    out.voice = arg;
-    out.valid = isSupportedVoice(arg);
-    if (out.valid) out.message = "[OK] Voice set to: " + arg;
-    else out.message = "Usage: /voice corie|semaine|southern_english_female";
-    return out;
-}
-
-bool applyVoiceCommand(const std::string& command, AppConfig& config, VoiceCommandResult& out) {
-    out = parseVoiceCommand(command);
-    if (!out.recognized) return false;
-    if (out.valid) config.tts_voice = out.voice;
-    return true;
-}
 
 Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& config) {
     Json::Value payload(Json::objectValue);
@@ -281,7 +250,7 @@ Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& con
 std::string buildTTSRequestUrl(const AppConfig& config) {
     std::string url = config.tts_endpoint_url;
     url = appendQueryParam(url, "play", "0");
-    url = appendQueryParam(url, "stream_audio_chunks", "1");
+    url = appendQueryParam(url, "return_audio", "1");
     return url;
 }
 
@@ -322,50 +291,6 @@ bool decodeBase64AudioResponse(const std::string& response_body,
     return decodeBase64(encoded, out.audio_bytes, error);
 }
 
-
-bool parseStreamedAudioChunks(const std::string& response_body,
-                              std::vector<std::vector<unsigned char>>& chunks,
-                              std::string& error) {
-    std::istringstream lines(response_body);
-    std::string line;
-    bool saw_done = false;
-    while (std::getline(lines, line)) {
-        line = trim_copy(line);
-        if (line.empty()) continue;
-
-        Json::CharReaderBuilder reader;
-        Json::Value root;
-        std::string errs;
-        std::istringstream ss(line);
-        if (!Json::parseFromStream(reader, ss, &root, &errs)) {
-            error = "invalid streamed JSON";
-            return false;
-        }
-
-        const std::string type = root.get("type", "").asString();
-        if (type == "audio_chunk") {
-            std::string encoded = root.get("audio_b64_wav", "").asString();
-            if (encoded.empty()) {
-                error = "missing audio_b64_wav field";
-                return false;
-            }
-            std::vector<unsigned char> bytes;
-            if (!decodeBase64(encoded, bytes, error)) return false;
-            chunks.push_back(std::move(bytes));
-        } else if (type == "error") {
-            error = root.get("detail", "stream error").asString();
-            return false;
-        } else if (type == "done") {
-            saw_done = true;
-        }
-    }
-
-    if (chunks.empty()) {
-        error = saw_done ? "no audio chunks returned" : "missing audio chunks";
-        return false;
-    }
-    return true;
-}
 
 bool maybeSpeakText(const std::string& text, const AppConfig& config) {
     if (!config.tts_enabled) return true;
@@ -411,31 +336,21 @@ bool maybeSpeakText(const std::string& text, const AppConfig& config) {
         return false;
     }
 
+    TTSResponseAudio audio;
     std::string error;
     const bool looks_like_wav = response.size() >= 12 && response.compare(0, 4, "RIFF") == 0 && response.compare(8, 4, "WAVE") == 0;
-    std::vector<std::vector<unsigned char>> audio_chunks;
-    if (content_type == "application/x-ndjson" || response.find(""audio_b64_wav"") != std::string::npos) {
-        if (!parseStreamedAudioChunks(response, audio_chunks, error)) {
-            std::cerr << "[Warn] TTS response invalid: " << error << "\n";
-            return false;
-        }
-    } else if (content_type.rfind("audio/", 0) == 0 || content_type == "application/octet-stream" || looks_like_wav) {
-        audio_chunks.push_back(std::vector<unsigned char>(response.begin(), response.end()));
-    } else {
-        TTSResponseAudio audio;
-        if (!decodeBase64AudioResponse(response, audio, error)) {
-            std::cerr << "[Warn] TTS response invalid: " << error << "\n";
-            return false;
-        }
-        audio_chunks.push_back(std::move(audio.audio_bytes));
+    if (content_type.rfind("audio/", 0) == 0 || content_type == "application/octet-stream" || looks_like_wav) {
+        audio.content_type = content_type.empty() ? "audio/wav" : content_type;
+        audio.audio_bytes.assign(response.begin(), response.end());
+    } else if (!decodeBase64AudioResponse(response, audio, error)) {
+        std::cerr << "[Warn] TTS response invalid: " << error << "\n";
+        return false;
     }
 
     std::string backend_used;
-    for (const auto& chunk : audio_chunks) {
-        if (!playAudioBytes(chunk, backend_used, error)) {
-            std::cerr << "[Warn] TTS playback failed: " << error << "\n";
-            return false;
-        }
+    if (!playAudioBytes(audio.audio_bytes, backend_used, error)) {
+        std::cerr << "[Warn] TTS playback failed: " << error << "\n";
+        return false;
     }
 
     std::cerr << "[Info] TTS playback backend: " << backend_used << "\n";

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -1,0 +1,319 @@
+#include "tts.hpp"
+
+#include <curl/curl.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+std::string trim_copy(std::string s) {
+    auto not_space = [](unsigned char c) { return !std::isspace(c); };
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
+    s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
+    return s;
+}
+
+std::string uppercase_copy(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::toupper(c); });
+    return s;
+}
+
+bool findExecutable(const std::string& name, std::string& out_path) {
+    const char* path_env = std::getenv("PATH");
+    if (!path_env) return false;
+    std::stringstream ss(path_env);
+    std::string dir;
+    while (std::getline(ss, dir, ':')) {
+        if (dir.empty()) continue;
+        std::filesystem::path candidate = std::filesystem::path(dir) / name;
+        if (::access(candidate.c_str(), X_OK) == 0) {
+            out_path = candidate.string();
+            return true;
+        }
+    }
+    return false;
+}
+
+size_t writeToString(void* contents, size_t size, size_t nmemb, void* userp) {
+    const size_t total = size * nmemb;
+    std::string* buffer = static_cast<std::string*>(userp);
+    buffer->append(static_cast<const char*>(contents), total);
+    return total;
+}
+
+bool decodeBase64(const std::string& input, std::vector<unsigned char>& out, std::string& error) {
+    static const int kInvalid = -1;
+    static int table[256];
+    static bool initialized = false;
+    if (!initialized) {
+        std::fill(std::begin(table), std::end(table), kInvalid);
+        for (int i = 'A'; i <= 'Z'; ++i) table[i] = i - 'A';
+        for (int i = 'a'; i <= 'z'; ++i) table[i] = i - 'a' + 26;
+        for (int i = '0'; i <= '9'; ++i) table[i] = i - '0' + 52;
+        table[static_cast<unsigned char>('+')] = 62;
+        table[static_cast<unsigned char>('/')] = 63;
+        initialized = true;
+    }
+
+    std::string cleaned;
+    cleaned.reserve(input.size());
+    for (unsigned char c : input) {
+        if (!std::isspace(c)) cleaned.push_back(static_cast<char>(c));
+    }
+
+    if (cleaned.empty()) {
+        error = "empty audio payload";
+        return false;
+    }
+    if (cleaned.size() % 4 != 0) {
+        error = "invalid base64 length";
+        return false;
+    }
+
+    out.clear();
+    out.reserve((cleaned.size() / 4) * 3);
+    for (size_t i = 0; i < cleaned.size(); i += 4) {
+        int vals[4];
+        int pad = 0;
+        for (int j = 0; j < 4; ++j) {
+            unsigned char c = static_cast<unsigned char>(cleaned[i + j]);
+            if (c == '=') {
+                vals[j] = 0;
+                ++pad;
+                continue;
+            }
+            vals[j] = table[c];
+            if (vals[j] == kInvalid) {
+                error = "invalid base64 character";
+                return false;
+            }
+        }
+        out.push_back(static_cast<unsigned char>((vals[0] << 2) | (vals[1] >> 4)));
+        if (pad < 2) out.push_back(static_cast<unsigned char>(((vals[1] & 0xF) << 4) | (vals[2] >> 2)));
+        if (pad < 1) out.push_back(static_cast<unsigned char>(((vals[2] & 0x3) << 6) | vals[3]));
+    }
+    return true;
+}
+
+bool writeAudioTempFile(const std::vector<unsigned char>& audio, std::string& out_path, std::string& error) {
+    char path_template[] = "/tmp/aimaster_tts_XXXXXX.wav";
+    int fd = ::mkstemps(path_template, 4);
+    if (fd < 0) {
+        error = std::string("temp file create failed: ") + std::strerror(errno);
+        return false;
+    }
+    ssize_t written = ::write(fd, audio.data(), audio.size());
+    ::close(fd);
+    if (written < 0 || static_cast<size_t>(written) != audio.size()) {
+        ::unlink(path_template);
+        error = std::string("temp file write failed: ") + std::strerror(errno);
+        return false;
+    }
+    out_path = path_template;
+    return true;
+}
+
+bool runPlayback(const std::vector<std::string>& argv, std::string& error) {
+    std::vector<char*> args;
+    args.reserve(argv.size() + 1);
+    for (const auto& arg : argv) args.push_back(const_cast<char*>(arg.c_str()));
+    args.push_back(nullptr);
+
+    pid_t pid = ::fork();
+    if (pid < 0) {
+        error = std::string("fork failed: ") + std::strerror(errno);
+        return false;
+    }
+    if (pid == 0) {
+        ::execv(args[0], args.data());
+        _exit(127);
+    }
+
+    int status = 0;
+    if (::waitpid(pid, &status, 0) < 0) {
+        error = std::string("waitpid failed: ") + std::strerror(errno);
+        return false;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        std::ostringstream oss;
+        oss << "player exited with status " << (WIFEXITED(status) ? WEXITSTATUS(status) : -1);
+        error = oss.str();
+        return false;
+    }
+    return true;
+}
+
+bool playAudioBytes(const std::vector<unsigned char>& audio, std::string& backend_used, std::string& error) {
+    std::string path;
+    if (!writeAudioTempFile(audio, path, error)) return false;
+
+    struct Backend {
+        const char* name;
+        std::vector<std::string> args;
+    };
+
+    std::vector<Backend> backends;
+    std::string exe;
+    if (findExecutable("ffplay", exe)) backends.push_back({"ffplay", {exe, "-nodisp", "-autoexit", "-loglevel", "error", path}});
+    if (findExecutable("paplay", exe)) backends.push_back({"paplay", {exe, path}});
+    if (findExecutable("aplay", exe)) backends.push_back({"aplay", {exe, path}});
+
+    if (backends.empty()) {
+        ::unlink(path.c_str());
+        error = "no playback backend found (tried ffplay, paplay, aplay)";
+        return false;
+    }
+
+    for (const auto& backend : backends) {
+        std::string backend_error;
+        if (runPlayback(backend.args, backend_error)) {
+            backend_used = backend.name;
+            ::unlink(path.c_str());
+            return true;
+        }
+        error = backend.name + std::string(": ") + backend_error;
+    }
+
+    ::unlink(path.c_str());
+    return false;
+}
+
+} // namespace
+
+SpeakCommandResult parseSpeakCommand(const std::string& command) {
+    SpeakCommandResult out;
+    std::string trimmed = trim_copy(command);
+    std::string upper = uppercase_copy(trimmed);
+    if (upper.rfind("/SPEAK", 0) != 0) return out;
+    out.recognized = true;
+
+    std::istringstream iss(trimmed);
+    std::string verb, arg;
+    iss >> verb >> arg;
+    arg = uppercase_copy(arg);
+    if (arg == "ON") {
+        out.enable = true;
+        out.message = "[OK] Speech output enabled.";
+    } else if (arg == "OFF") {
+        out.enable = false;
+        out.message = "[OK] Speech output disabled.";
+    } else {
+        out.message = "Usage: /speak on|off";
+    }
+    return out;
+}
+
+
+bool applySpeakCommand(const std::string& command, AppConfig& config, SpeakCommandResult& out) {
+    out = parseSpeakCommand(command);
+    if (!out.recognized) return false;
+    std::string upper = uppercase_copy(trim_copy(command));
+    if (upper == "/SPEAK ON") config.tts_enabled = true;
+    else if (upper == "/SPEAK OFF") config.tts_enabled = false;
+    return true;
+}
+
+Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& config) {
+    Json::Value payload(Json::objectValue);
+    payload["text"] = text;
+    if (!config.tts_voice.empty()) payload["voice"] = config.tts_voice;
+    if (!config.tts_speaker.empty()) payload["speaker"] = config.tts_speaker;
+    return payload;
+}
+
+bool decodeBase64AudioResponse(const std::string& response_body,
+                               TTSResponseAudio& out,
+                               std::string& error) {
+    Json::CharReaderBuilder reader;
+    Json::Value root;
+    std::string errs;
+    std::istringstream ss(response_body);
+    if (!Json::parseFromStream(reader, ss, &root, &errs)) {
+        error = "invalid JSON";
+        return false;
+    }
+    const char* fields[] = {"audio", "audio_base64", "wav_base64"};
+    std::string encoded;
+    for (const char* field : fields) {
+        if (root.isMember(field) && root[field].isString()) {
+            encoded = root[field].asString();
+            break;
+        }
+    }
+    if (encoded.empty()) {
+        error = "missing audio field";
+        return false;
+    }
+    out.content_type = root.get("content_type", "audio/wav").asString();
+    return decodeBase64(encoded, out.audio_bytes, error);
+}
+
+bool maybeSpeakText(const std::string& text, const AppConfig& config) {
+    if (!config.tts_enabled) return true;
+    if (trim_copy(text).empty()) return true;
+
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        std::cerr << "[Warn] TTS unavailable: curl init failed\n";
+        return false;
+    }
+
+    std::string response;
+    std::string payload_str = Json::writeString(Json::StreamWriterBuilder(), buildTTSRequestPayload(text, config));
+    struct curl_slist* headers = nullptr;
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+
+    curl_easy_setopt(curl, CURLOPT_URL, config.tts_endpoint_url.c_str());
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload_str.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(payload_str.size()));
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, config.tts_timeout_seconds);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, config.tts_timeout_seconds);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToString);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
+    CURLcode res = curl_easy_perform(curl);
+    long http_status = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_status);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    if (res != CURLE_OK) {
+        std::cerr << "[Warn] TTS request failed: " << curl_easy_strerror(res) << "\n";
+        return false;
+    }
+    if (http_status < 200 || http_status >= 300) {
+        std::cerr << "[Warn] TTS request failed: HTTP " << http_status << "\n";
+        return false;
+    }
+
+    TTSResponseAudio audio;
+    std::string error;
+    if (!decodeBase64AudioResponse(response, audio, error)) {
+        std::cerr << "[Warn] TTS response invalid: " << error << "\n";
+        return false;
+    }
+
+    std::string backend_used;
+    if (!playAudioBytes(audio.audio_bytes, backend_used, error)) {
+        std::cerr << "[Warn] TTS playback failed: " << error << "\n";
+        return false;
+    }
+
+    std::cerr << "[Info] TTS playback backend: " << backend_used << "\n";
+    return true;
+}

--- a/tests/chat_provider_tests.cpp
+++ b/tests/chat_provider_tests.cpp
@@ -1,3 +1,5 @@
+void run_tts_tests();
+
 #include "chat_provider.hpp"
 #include "config_loader.h"
 
@@ -90,6 +92,7 @@ int main() {
     test_ollama_payload_mapping();
     test_model_list_parsing();
     test_config_loader_fallback();
+    run_tts_tests();
     std::cout << "chat_provider_tests passed\n";
     return 0;
 }

--- a/tests/tts_tests.cpp
+++ b/tests/tts_tests.cpp
@@ -46,12 +46,12 @@ static void test_build_payload_and_decode_success() {
     cfg.tts_speaker = "narrator";
     Json::Value payload = buildTTSRequestPayload("hello", cfg);
     assert(payload["text"].asString() == "hello");
-    assert(payload["return_type"].asString() == "base64");
-    assert(payload["format"].asString() == "wav");
-    assert(payload["response_format"].asString() == "wav");
+    assert(payload["prompt"].asString() == "hello");
     assert(payload["voice"].asString() == "en-us");
     assert(payload["speaker"].asString() == "narrator");
-    assert(payload["speaker_id"].asString() == "narrator");
+
+    cfg.tts_endpoint_url = "http://127.0.0.1:8092/speak";
+    assert(buildTTSRequestUrl(cfg) == "http://127.0.0.1:8092/speak?play=0&return_audio=1");
 
     TTSResponseAudio audio;
     std::string err;

--- a/tests/tts_tests.cpp
+++ b/tests/tts_tests.cpp
@@ -40,6 +40,26 @@ static void test_speak_state_behavior() {
     assert(!cfg.tts_enabled);
 }
 
+
+static void test_voice_command() {
+    auto corie = parseVoiceCommand("/voice corie");
+    assert(corie.recognized);
+    assert(corie.valid);
+    assert(corie.voice == "corie");
+
+    AppConfig cfg;
+    VoiceCommandResult res;
+    bool handled = applyVoiceCommand("/voice semaine", cfg, res);
+    assert(handled);
+    assert(res.valid);
+    assert(cfg.tts_voice == "semaine");
+
+    handled = applyVoiceCommand("/voice nope", cfg, res);
+    assert(handled);
+    assert(!res.valid);
+    assert(cfg.tts_voice == "semaine");
+}
+
 static void test_build_payload_and_decode_success() {
     AppConfig cfg;
     cfg.tts_voice = "en-us";
@@ -51,7 +71,7 @@ static void test_build_payload_and_decode_success() {
     assert(payload["speaker"].asString() == "narrator");
 
     cfg.tts_endpoint_url = "http://127.0.0.1:8092/speak";
-    assert(buildTTSRequestUrl(cfg) == "http://127.0.0.1:8092/speak?play=0&return_audio=1");
+    assert(buildTTSRequestUrl(cfg) == "http://127.0.0.1:8092/speak?play=0&stream_audio_chunks=1");
 
     TTSResponseAudio audio;
     std::string err;
@@ -90,6 +110,7 @@ static void test_decode_failure_paths() {
 void run_tts_tests() {
     test_parse_speak_command();
     test_speak_state_behavior();
+    test_voice_command();
     test_build_payload_and_decode_success();
     test_decode_failure_paths();
     std::cout << "tts_tests passed\n";

--- a/tests/tts_tests.cpp
+++ b/tests/tts_tests.cpp
@@ -1,0 +1,87 @@
+#include "tts.hpp"
+
+#include <cassert>
+#include <iostream>
+
+static void test_parse_speak_command() {
+    auto on = parseSpeakCommand("/speak on");
+    assert(on.recognized);
+    assert(on.enable);
+
+    auto off = parseSpeakCommand(" /SPEAK off ");
+    assert(off.recognized);
+    assert(!off.enable);
+
+    auto bad = parseSpeakCommand("/speak maybe");
+    assert(bad.recognized);
+    assert(bad.message == "Usage: /speak on|off");
+
+    auto other = parseSpeakCommand("hello world");
+    assert(!other.recognized);
+}
+
+static void test_speak_state_behavior() {
+    AppConfig cfg;
+    cfg.tts_enabled = false;
+    SpeakCommandResult res;
+
+    bool handled = applySpeakCommand("/speak on", cfg, res);
+    assert(handled);
+    assert(cfg.tts_enabled);
+    assert(res.message == "[OK] Speech output enabled.");
+
+    handled = applySpeakCommand("/speak off", cfg, res);
+    assert(handled);
+    assert(!cfg.tts_enabled);
+    assert(res.message == "[OK] Speech output disabled.");
+
+    handled = applySpeakCommand("/speak maybe", cfg, res);
+    assert(handled);
+    assert(!cfg.tts_enabled);
+}
+
+static void test_build_payload_and_decode_success() {
+    AppConfig cfg;
+    cfg.tts_voice = "en-us";
+    cfg.tts_speaker = "narrator";
+    Json::Value payload = buildTTSRequestPayload("hello", cfg);
+    assert(payload["text"].asString() == "hello");
+    assert(payload["voice"].asString() == "en-us");
+    assert(payload["speaker"].asString() == "narrator");
+
+    TTSResponseAudio audio;
+    std::string err;
+    bool ok = decodeBase64AudioResponse(R"({"audio":"aGVsbG8=","content_type":"audio/wav"})", audio, err);
+    assert(ok);
+    assert(err.empty());
+    std::string decoded(audio.audio_bytes.begin(), audio.audio_bytes.end());
+    assert(decoded == "hello");
+    assert(audio.content_type == "audio/wav");
+}
+
+static void test_decode_failure_paths() {
+    TTSResponseAudio audio;
+    std::string err;
+
+    bool ok = decodeBase64AudioResponse("not-json", audio, err);
+    assert(!ok);
+    assert(err == "invalid JSON");
+
+    err.clear();
+    ok = decodeBase64AudioResponse(R"({"message":"missing"})", audio, err);
+    assert(!ok);
+    assert(err == "missing audio field");
+
+    err.clear();
+    ok = decodeBase64AudioResponse(R"({"audio":"%%%"})", audio, err);
+    assert(!ok);
+    assert(!err.empty());
+}
+
+void run_tts_tests() {
+    test_parse_speak_command();
+    test_speak_state_behavior();
+    test_build_payload_and_decode_success();
+    test_decode_failure_paths();
+    std::cout << "tts_tests passed\n";
+}

--- a/tests/tts_tests.cpp
+++ b/tests/tts_tests.cpp
@@ -41,25 +41,6 @@ static void test_speak_state_behavior() {
 }
 
 
-static void test_voice_command() {
-    auto corie = parseVoiceCommand("/voice corie");
-    assert(corie.recognized);
-    assert(corie.valid);
-    assert(corie.voice == "corie");
-
-    AppConfig cfg;
-    VoiceCommandResult res;
-    bool handled = applyVoiceCommand("/voice semaine", cfg, res);
-    assert(handled);
-    assert(res.valid);
-    assert(cfg.tts_voice == "semaine");
-
-    handled = applyVoiceCommand("/voice nope", cfg, res);
-    assert(handled);
-    assert(!res.valid);
-    assert(cfg.tts_voice == "semaine");
-}
-
 static void test_build_payload_and_decode_success() {
     AppConfig cfg;
     cfg.tts_voice = "en-us";
@@ -71,7 +52,7 @@ static void test_build_payload_and_decode_success() {
     assert(payload["speaker"].asString() == "narrator");
 
     cfg.tts_endpoint_url = "http://127.0.0.1:8092/speak";
-    assert(buildTTSRequestUrl(cfg) == "http://127.0.0.1:8092/speak?play=0&stream_audio_chunks=1");
+    assert(buildTTSRequestUrl(cfg) == "http://127.0.0.1:8092/speak?play=0&return_audio=1");
 
     TTSResponseAudio audio;
     std::string err;
@@ -110,7 +91,6 @@ static void test_decode_failure_paths() {
 void run_tts_tests() {
     test_parse_speak_command();
     test_speak_state_behavior();
-    test_voice_command();
     test_build_payload_and_decode_success();
     test_decode_failure_paths();
     std::cout << "tts_tests passed\n";

--- a/tests/tts_tests.cpp
+++ b/tests/tts_tests.cpp
@@ -46,8 +46,12 @@ static void test_build_payload_and_decode_success() {
     cfg.tts_speaker = "narrator";
     Json::Value payload = buildTTSRequestPayload("hello", cfg);
     assert(payload["text"].asString() == "hello");
+    assert(payload["return_type"].asString() == "base64");
+    assert(payload["format"].asString() == "wav");
+    assert(payload["response_format"].asString() == "wav");
     assert(payload["voice"].asString() == "en-us");
     assert(payload["speaker"].asString() == "narrator");
+    assert(payload["speaker_id"].asString() == "narrator");
 
     TTSResponseAudio audio;
     std::string err;
@@ -71,6 +75,11 @@ static void test_decode_failure_paths() {
     ok = decodeBase64AudioResponse(R"({"message":"missing"})", audio, err);
     assert(!ok);
     assert(err == "missing audio field");
+
+    err.clear();
+    ok = decodeBase64AudioResponse(R"({"data":{"audio_data":"aGVsbG8="}})", audio, err);
+    assert(ok);
+    assert(std::string(audio.audio_bytes.begin(), audio.audio_bytes.end()) == "hello");
 
     err.clear();
     ok = decodeBase64AudioResponse(R"({"audio":"%%%"})", audio, err);


### PR DESCRIPTION
### Motivation
- Provide an additive, local `/speak` CLI toggle so users can enable/disable text‑to‑speech for assistant replies without sending the command to the LLM. 
- Make TTS configurable and robust (endpoint URL, timeout, optional voice/speaker), with portable, lightweight playback and clear failure handling so normal console output never fails on audio errors. 
- Keep backward compatibility by leaving speech off by default unless explicitly enabled. 

### Description
- Added a small TTS helper module (`include/tts.hpp`, `src/tts.cpp`) that builds a JSON `text` payload (with optional `voice`/`speaker`), POSTs to a configurable endpoint, parses JSON responses for base64 audio (`audio`, `audio_base64`, `wav_base64`), decodes the payload, writes a temporary WAV file, and plays it using the first available backend in order `ffplay`, `paplay`, `aplay`. 
- Wired the TTS step into the response pipeline so speech is triggered after the final assistant reply is produced (`src/ollama_client.cpp` calls `maybeSpeakText(...)`), and added local `/speak on` and `/speak off` handling in both normal and interactive modes so the command is never sent to the LLM. 
- Added configuration and environment overrides in `AppConfig` (`include/config_loader.h` + parsing/saving in `src/config_loader.cpp`) with sensible defaults: `tts_enabled=false`, `tts_endpoint_url=http://127.0.0.1:5000/tts`, `tts_timeout_seconds=10`, plus `tts_voice` and `tts_speaker`. 
- Updated CLI/help/docs: `README.md`, `config-example.txt`, `cmds.csv`, and Makefile/test wiring to include `tts.o` and unit tests; added unit tests (`tests/tts_tests.cpp`) covering `/speak` parsing/state, response base64 decode success, and failure paths, and wired tests into `tests/chat_provider_tests.cpp`. 

### Testing
- Attempted `make test` in the execution environment but compilation failed with `fatal error: json/json.h: No such file or directory`, so the test binary could not be built in this environment (missing jsoncpp dev headers). 
- Ran static checks/grep for merge markers and common diagnostics (no leftover conflict markers remain), and ran repository network inspection which could not fetch the Quick‑Piper repo due to outbound GitHub `403 Forbidden` from this environment. 
- Added unit tests for the `/speak` parsing/state behaviour and for TTS response decoding and failure cases (`tests/tts_tests.cpp`), but these tests were not executed here because the test build step could not complete. 

Files changed (high level): `include/tts.hpp`, `src/tts.cpp`, `include/config_loader.h`, `src/config_loader.cpp`, `src/ollama_client.cpp`, `Makefile`, `README.md`, `config-example.txt`, `cmds.csv`, and new tests `tests/tts_tests.cpp` plus minor test wiring in `tests/chat_provider_tests.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf036b2c48832d9976ad338257938e)