### PR TITLE
Load UART welcome banner from file, add /RESET, and handle delete/backspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ config.txt
 
 # outputted code
 code/*.txt
+dist/
 ollama_cli
 AImaster
 rag/6502DevelopmentPackage.pdf

--- a/README.md
+++ b/README.md
@@ -215,6 +215,6 @@ scripts/build_deb.sh --skip-build
 scripts/rebuild.sh
 ```
 
-The installed service runs system-wide under the dedicated `aimaster` account with `WorkingDirectory=/var/lib/aimaster`. If your deployment needs a different serial device path, provider URL, or TTS settings, edit `/var/lib/aimaster/config.txt` after installation and restart the service.
+The installed service runs system-wide under the dedicated `aimaster` account with `WorkingDirectory=/var/lib/aimaster`. The packaged default UART welcome banner is installed at `/usr/share/aimaster/welcome.txt`, and the default `welcome_message_file` points there. If your deployment needs a different serial device path, provider URL, TTS settings, or banner file, edit `/var/lib/aimaster/config.txt` after installation and restart the service.
 
 For update/redeploy workflows, `scripts/rebuild.sh` fetches and pulls the latest refs, presents an interactive branch list (including the newest fetched branch), checks out the selected branch, rebuilds the Debian package with `scripts/build_deb.sh`, installs it, restores any existing `/var/lib/aimaster/config.txt`, and restarts `aimaster.service`.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Request payloads follow the upstream examples by sending `text` (and `prompt` as
 
 - Confirm `/speak on` is enabled.
 - Confirm one of `paplay`, `aplay`, or `ffplay` is installed and available on `PATH`.
-- Check stderr for the selected playback backend or warning message.
+- Check stderr for playback warnings or error messages.
 - Verify the endpoint returns playable WAV/base64 content.
 
 #### Endpoint connectivity

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ These config keys are supported in `config.txt` and `config-example.txt`:
 tts_enabled=false
 tts_endpoint_url=http://127.0.0.1:8092/speak
 tts_timeout_seconds=10
+tts_output_device=plughw:0,0
 #tts_voice=en-us
 #tts_speaker=narrator
 ```
@@ -173,11 +174,12 @@ Environment overrides are also supported:
 - `AIMASTER_TTS_ENABLED`
 - `AIMASTER_TTS_ENDPOINT`
 - `AIMASTER_TTS_TIMEOUT_SECONDS`
+- `AIMASTER_TTS_OUTPUT_DEVICE`
 - `AIMASTER_TTS_VOICE`
 - `AIMASTER_TTS_SPEAKER`
 - `AIMASTER_TTS_BACKENDS` (comma-separated override such as `aplay,ffplay,paplay`)
 
-Request payloads follow the upstream examples by sending `text` (and `prompt` as a compatibility alias), plus optional `voice` and `speaker` values in the JSON body. The client appends `play=0&stream_audio_chunks=1` to the configured `/speak` URL so Quick-Piper can stream base64 WAV chunks for incremental playback; for resilience it also accepts direct WAV responses and compatible JSON/base64 fields such as `audio`, `audio_base64`, `wav_base64`, `audio_data`, and nested `data.*` variants.
+Request payloads follow the upstream examples by sending `text` (and `prompt` as a compatibility alias), plus optional `voice` and `speaker` values in the JSON body. The client appends `play=0&stream_audio_chunks=1` to the configured `/speak` URL so Quick-Piper can stream base64 WAV chunks for incremental playback; for resilience it also accepts direct WAV responses and compatible JSON/base64 fields such as `audio`, `audio_base64`, `wav_base64`, `audio_data`, and nested `data.*` variants. Use `/sound` to list ALSA playback devices and save a preferred `tts_output_device`; the default is `plughw:0,0`.
 
 ### Troubleshooting audio
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ Example build commands:
 scripts/build_deb.sh
 scripts/build_deb.sh --version 1.0.0
 scripts/build_deb.sh --skip-build
+scripts/rebuild.sh
 ```
 
 The installed service runs system-wide under the dedicated `aimaster` account with `WorkingDirectory=/var/lib/aimaster`. If your deployment needs a different serial device path, provider URL, or TTS settings, edit `/var/lib/aimaster/config.txt` after installation and restart the service.
+
+For update/redeploy workflows, `scripts/rebuild.sh` fetches and pulls the latest refs, presents an interactive branch list (including the newest fetched branch), checks out the selected branch, rebuilds the Debian package with `scripts/build_deb.sh`, installs it, restores any existing `/var/lib/aimaster/config.txt`, and restarts `aimaster.service`.

--- a/assets/welcome.txt
+++ b/assets/welcome.txt
@@ -1,0 +1,6 @@
+HH   HH  OOOOO  LL      LL    YY   YY        6666   0000   0000
+HH   HH OO   OO LL      LL     YY YY        66     00  00 00  00
+HHHHHHH OO   OO LL      LL      YYY        66      00  00 00  00
+HH   HH OO   OO LL      LL      YYY        66666   00  00 00  00
+HH   HH OO   OO LL      LL      YYY        66  66  00  00 00  00
+HH   HH  OOOOO  LLLLLLL LLLLLLL YYY         6666    0000   0000

--- a/cmds.csv
+++ b/cmds.csv
@@ -2,6 +2,7 @@ ASK,Ask the model a question and receive an answer - DEPRECATED USE INT instead.
 READ,Provide context and send the contents of a file to the model for absorption into the current chat.
 RESET,Clear the current chat history (useful to start a fresh conversation).
 /RESET,Clear the UART screen and redraw the welcome banner.
+/sound,List or set the TTS output device.
 CFG,Show current configuration information.
 HELP,List available commands.
 INT, Enter interactive mode - user /bye to exit.

--- a/cmds.csv
+++ b/cmds.csv
@@ -1,6 +1,7 @@
 ASK,Ask the model a question and receive an answer - DEPRECATED USE INT instead.
 READ,Provide context and send the contents of a file to the model for absorption into the current chat.
 RESET,Clear the current chat history (useful to start a fresh conversation).
+/RESET,Clear the UART screen and redraw the welcome banner.
 CFG,Show current configuration information.
 HELP,List available commands.
 INT, Enter interactive mode - user /bye to exit.

--- a/config-example.txt
+++ b/config-example.txt
@@ -3,6 +3,7 @@ baudrate=2400
 serial_delay_ms=50
 serial_newline=CR
 serial_wrap_cols=80
+welcome_message_file=assets/welcome.txt
 
 #provider_type=ollama_native
 #ollama_url=http://192.168.1.154:11434/api/chat

--- a/config-example.txt
+++ b/config-example.txt
@@ -3,7 +3,7 @@ baudrate=2400
 serial_delay_ms=50
 serial_newline=CR
 serial_wrap_cols=80
-welcome_message_file=assets/welcome.txt
+welcome_message_file=/usr/share/aimaster/welcome.txt
 
 #provider_type=ollama_native
 #ollama_url=http://192.168.1.154:11434/api/chat

--- a/config-example.txt
+++ b/config-example.txt
@@ -29,5 +29,6 @@ commands_csv=cmds.csv
 tts_enabled=false
 tts_endpoint_url=http://127.0.0.1:8092/speak
 tts_timeout_seconds=10
+tts_output_device=plughw:0,0
 #tts_voice=en-us
 #tts_speaker=narrator

--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -13,7 +13,7 @@ struct AppConfig {
 
     int serial_delay_ms = 50;
     std::string serial_newline = "CRLF"; // NEW: CRLF (default), LFCR, LF, CR
-    std::string welcome_message_file = "assets/welcome.txt";
+    std::string welcome_message_file = "/usr/share/aimaster/welcome.txt";
 
     // Ollama / provider compatibility
     std::string ollama_url = "http://localhost:11434";

--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -40,6 +40,7 @@ struct AppConfig {
     long tts_timeout_seconds = 10;
     std::string tts_voice;
     std::string tts_speaker;
+    std::string tts_output_device = "plughw:0,0";
 
     // RAG retrieval defaults (used by ASK/INT when RAG is active)
     int rag_chunks = 25;

--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -13,6 +13,7 @@ struct AppConfig {
 
     int serial_delay_ms = 50;
     std::string serial_newline = "CRLF"; // NEW: CRLF (default), LFCR, LF, CR
+    std::string welcome_message_file = "assets/welcome.txt";
 
     // Ollama / provider compatibility
     std::string ollama_url = "http://localhost:11434";

--- a/include/serial_handler.h
+++ b/include/serial_handler.h
@@ -9,6 +9,8 @@ extern bool serial_available;
 bool initSerial(const std::string& port, int baudrate);
 void serialSend(const std::string& data);
 void setSerialSendDelay(int delay_ms);
+void setWelcomeMessageFile(const std::string& path);
+void serialResetTerminal();
 
 // New: configure how '\n' is written to the wire.
 // Accepts: "CRLF" (default), "LFCR", "LF", "CR" (case-insensitive, others -> default)

--- a/include/serial_handler.h
+++ b/include/serial_handler.h
@@ -4,13 +4,15 @@
 #include <string>
 #include <functional>
 
+struct AppConfig;
+
 extern bool serial_available;
 
 bool initSerial(const std::string& port, int baudrate);
 void serialSend(const std::string& data);
 void setSerialSendDelay(int delay_ms);
 void setWelcomeMessageFile(const std::string& path);
-void serialResetTerminal();
+void serialResetTerminal(const AppConfig& config);
 
 // New: configure how '\n' is written to the wire.
 // Accepts: "CRLF" (default), "LFCR", "LF", "CR" (case-insensitive, others -> default)

--- a/include/tts.hpp
+++ b/include/tts.hpp
@@ -21,6 +21,12 @@ struct TTSResponseAudio {
     std::string content_type;
 };
 
+struct PlaybackDevice {
+    std::string id;
+    std::string description;
+    bool is_default = false;
+};
+
 SpeakCommandResult parseSpeakCommand(const std::string& command);
 bool applySpeakCommand(const std::string& command, AppConfig& config, SpeakCommandResult& out);
 Json::Value buildTTSRequestPayload(const std::string& text, const AppConfig& config);
@@ -28,6 +34,7 @@ std::string buildTTSRequestUrl(const AppConfig& config);
 bool decodeBase64AudioResponse(const std::string& response_body,
                                TTSResponseAudio& out,
                                std::string& error);
+std::vector<PlaybackDevice> listPlaybackDevices(std::string& error);
 
 bool maybeSpeakText(const std::string& text, const AppConfig& config);
 

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -65,6 +65,7 @@ install -m 0644 "$ROOT_DIR/packaging/systemd/aimaster.service" "$PKG_ROOT/usr/li
 install -m 0755 "$ROOT_DIR/packaging/systemd/aimaster-service.sh" "$PKG_ROOT/usr/lib/aimaster/aimaster-service.sh"
 install -m 0644 "$ROOT_DIR/config-example.txt" "$PKG_ROOT/usr/share/aimaster/config-example.txt"
 install -m 0644 "$ROOT_DIR/cmds.csv" "$PKG_ROOT/usr/share/aimaster/cmds.csv"
+install -m 0644 "$ROOT_DIR/assets/welcome.txt" "$PKG_ROOT/usr/share/aimaster/welcome.txt"
 install -m 0644 "$ROOT_DIR/README.md" "$PKG_ROOT/usr/share/doc/aimaster/README.md"
 install -m 0644 "$ROOT_DIR/LICENSE" "$PKG_ROOT/usr/share/doc/aimaster/LICENSE"
 install -m 0755 "$ROOT_DIR/packaging/debian/postinst" "$DEBIAN_DIR/postinst"

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SERVICE_NAME="aimaster.service"
+SERVICE_CONFIG="/var/lib/aimaster/config.txt"
+TMP_CONFIG_BACKUP=""
+
+cleanup() {
+  if [[ -n "$TMP_CONFIG_BACKUP" && -f "$TMP_CONFIG_BACKUP" ]]; then
+    rm -f "$TMP_CONFIG_BACKUP"
+  fi
+}
+trap cleanup EXIT
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+for cmd in git make dpkg dpkg-deb sudo systemctl; do
+  require_cmd "$cmd"
+done
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+echo "Current branch: $current_branch"
+
+echo "Fetching latest refs..."
+git fetch --all --prune
+
+echo "Pulling latest changes for $current_branch..."
+git pull --ff-only
+
+newest_remote_ref="$(
+  git for-each-ref --sort=-committerdate --format='%(refname:short)' refs/remotes \
+    | grep -v '^origin/HEAD$' \
+    | head -n1 \
+    | sed 's#^origin/##'
+)"
+if [[ -n "$newest_remote_ref" ]]; then
+  echo "Newest fetched branch: $newest_remote_ref"
+fi
+
+mapfile -t branch_lines < <(
+  {
+    git for-each-ref --sort=-committerdate --format='%(committerdate:iso8601)|local|%(refname:short)|%(upstream:short)' refs/heads
+    git for-each-ref --sort=-committerdate --format='%(committerdate:iso8601)|remote|%(refname:short)|' refs/remotes \
+      | grep -vE '\|remote\|origin/HEAD\|'
+  } | awk -F'|' '
+      {
+        key=$3
+        sub(/^origin\//, "", key)
+      }
+      !seen[key]++ {
+        print $0
+      }
+    '
+)
+
+if [[ ${#branch_lines[@]} -eq 0 ]]; then
+  echo "No branches available to select." >&2
+  exit 1
+fi
+
+echo
+echo "Available branches:"
+selected_default=1
+for i in "${!branch_lines[@]}"; do
+  IFS='|' read -r branch_date branch_kind branch_name branch_upstream <<<"${branch_lines[$i]}"
+  display_name="$branch_name"
+  note=""
+
+  if [[ "$branch_kind" == "remote" ]]; then
+    display_name="${branch_name#origin/}"
+    note="remote"
+  else
+    note="local"
+  fi
+
+  if [[ "$display_name" == "$current_branch" ]]; then
+    note="$note,current"
+    selected_default=$((i + 1))
+  fi
+  if [[ -n "$newest_remote_ref" && "$display_name" == "$newest_remote_ref" ]]; then
+    note="$note,newest"
+  fi
+  if [[ -n "$branch_upstream" ]]; then
+    note="$note,tracks ${branch_upstream#origin/}"
+  fi
+
+  printf ' [%d] %s (%s; %s)\n' "$((i + 1))" "$display_name" "$branch_date" "$note"
+done
+
+echo
+read -r -p "Select branch [${selected_default}]: " selection
+selection="${selection:-$selected_default}"
+if ! [[ "$selection" =~ ^[0-9]+$ ]] || (( selection < 1 || selection > ${#branch_lines[@]} )); then
+  echo "Invalid selection: $selection" >&2
+  exit 1
+fi
+
+IFS='|' read -r _selected_date selected_kind selected_name _selected_upstream <<<"${branch_lines[$((selection - 1))]}"
+checkout_branch="$selected_name"
+if [[ "$selected_kind" == "remote" ]]; then
+  local_name="${selected_name#origin/}"
+  if git show-ref --verify --quiet "refs/heads/$local_name"; then
+    git checkout "$local_name"
+    git pull --ff-only origin "$local_name"
+  else
+    git checkout -b "$local_name" --track "$selected_name"
+  fi
+  checkout_branch="$local_name"
+else
+  git checkout "$selected_name"
+  git pull --ff-only
+fi
+
+echo "Building Debian package for branch: $checkout_branch"
+./scripts/build_deb.sh
+
+package_path="$(find "$ROOT_DIR/dist/deb" -maxdepth 1 -type f -name '*.deb' -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
+if [[ -z "$package_path" ]]; then
+  echo "No Debian package found in dist/deb." >&2
+  exit 1
+fi
+
+echo "Using package: $package_path"
+
+if sudo test -f "$SERVICE_CONFIG"; then
+  TMP_CONFIG_BACKUP="$(mktemp)"
+  sudo cp "$SERVICE_CONFIG" "$TMP_CONFIG_BACKUP"
+  echo "Backed up existing service config from $SERVICE_CONFIG"
+fi
+
+sudo dpkg -i "$package_path"
+
+if [[ -n "$TMP_CONFIG_BACKUP" && -f "$TMP_CONFIG_BACKUP" ]]; then
+  sudo install -o aimaster -g aimaster -m 0640 "$TMP_CONFIG_BACKUP" "$SERVICE_CONFIG"
+  echo "Restored existing service config to $SERVICE_CONFIG"
+fi
+
+sudo systemctl restart "$SERVICE_NAME"
+sudo systemctl --no-pager --full status "$SERVICE_NAME" || true
+
+echo "Rebuild, package install, and service restart complete."

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -101,6 +101,7 @@ bool loadConfig(const std::string& path, AppConfig& out) {
         else if (key == "tts_timeout_seconds") { long v; if (parse_long(val, v) && v > 0) out.tts_timeout_seconds = v; }
         else if (key == "tts_voice") out.tts_voice = val;
         else if (key == "tts_speaker") out.tts_speaker = val;
+        else if (key == "tts_output_device") out.tts_output_device = val;
         else if (key == "tts_enabled") { bool v; if (parse_bool(val, v)) out.tts_enabled = v; }
         else if (key == "extra_header") parse_extra_header(val, out.extra_headers);
         else if (key == "rag_chunks") { int v; if (parse_int(val, v) && v > 0) out.rag_chunks = v; }
@@ -122,6 +123,7 @@ bool loadConfig(const std::string& path, AppConfig& out) {
     if (const char* env = std::getenv("AIMASTER_TTS_TIMEOUT_SECONDS")) { long v; if (parse_long(env, v) && v > 0) out.tts_timeout_seconds = v; }
     if (const char* env = std::getenv("AIMASTER_TTS_VOICE")) out.tts_voice = env;
     if (const char* env = std::getenv("AIMASTER_TTS_SPEAKER")) out.tts_speaker = env;
+    if (const char* env = std::getenv("AIMASTER_TTS_OUTPUT_DEVICE")) out.tts_output_device = env;
 
     return true;
 }
@@ -154,6 +156,7 @@ bool saveConfig(const std::string& path, const AppConfig& cfg) {
     out << "tts_timeout_seconds=" << cfg.tts_timeout_seconds << "\n";
     if (!cfg.tts_voice.empty()) out << "tts_voice=" << cfg.tts_voice << "\n";
     if (!cfg.tts_speaker.empty()) out << "tts_speaker=" << cfg.tts_speaker << "\n";
+    if (!cfg.tts_output_device.empty()) out << "tts_output_device=" << cfg.tts_output_device << "\n";
     for (const auto& kv : cfg.extra_headers) out << "extra_header=" << kv.first << ": " << kv.second << "\n";
     out << "rag_chunks=" << cfg.rag_chunks << "\n";
     out << "rag_threshold=" << cfg.rag_threshold << "\n";

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -83,6 +83,7 @@ bool loadConfig(const std::string& path, AppConfig& out) {
         else if (key == "baudrate")    { int v; if (parse_int(val, v)) out.baudrate = v; }
         else if (key == "serial_delay_ms") { int v; if (parse_int(val, v) && v>=0) out.serial_delay_ms = v; }
         else if (key == "serial_newline")  { out.serial_newline = val; }
+        else if (key == "welcome_message_file") { out.welcome_message_file = val; }
         else if (key == "ollama_url")  out.ollama_url = val;
         else if (key == "ollama_model") out.ollama_model = val;
         else if (key == "ollama_timeout_seconds") { long v; if (parse_long(val, v) && v>=0) out.ollama_timeout_seconds = v; }
@@ -134,6 +135,7 @@ bool saveConfig(const std::string& path, const AppConfig& cfg) {
     out << "baudrate=" << cfg.baudrate << "\n";
     out << "serial_delay_ms=" << cfg.serial_delay_ms << "\n";
     out << "serial_newline=" << cfg.serial_newline << "\n";
+    out << "welcome_message_file=" << cfg.welcome_message_file << "\n";
     out << "ollama_url=" << cfg.ollama_url << "\n";
     out << "ollama_model=" << cfg.ollama_model << "\n";
     out << "ollama_timeout_seconds=" << cfg.ollama_timeout_seconds << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -222,6 +222,9 @@ setSerialSendDelay(config.serial_delay_ms);      // <- make sure this line exist
         std::cerr << "Warning: No serial port available. Using console mode." << std::endl;
     }
 if (serial_available) {
+serialResetTerminal(config);
+}
+if (serial_available) {
 startSerialListener([&](const std::string& line) {
     try {
                 setCurrentCommandSource(CommandSource::SERIAL);  // <-- add this line

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -238,7 +238,15 @@ startSerialListener([&](const std::string& line) {
         
 //serialSend(modelPrompt(config, "> "));
 } else {
-            (void)execute_command(line, config, CommandSource::SERIAL);
+            Json::Value result = execute_command(line, config, CommandSource::SERIAL);
+            const bool prompt_emitted = result.get("prompt_emitted", false).asBool();
+            if (!prompt_emitted && !ReadAwait_IsActive()) {
+                if (SerialINT_IsActive()) {
+                    route_output("-> ", false);
+                } else {
+                    route_output(modelPrompt(config, "> "), false);
+                }
+            }
         }
     } catch (...) {
         std::cerr << "[Warning] exception in serial command handler\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,6 +189,7 @@ int main() {
     // After loadConfig("config.txt", config);
 setSerialWrapColumns(config.serial_wrap_cols);
 AIMaster_RAG_ConfigureRemote(config.ollama_url, config.ollama_model);
+setWelcomeMessageFile(config.welcome_message_file);
 // Ping Ollama server with 2s timeout (non-fatal)
     {
         long http_code = 0;

--- a/src/ollama_client.cpp
+++ b/src/ollama_client.cpp
@@ -537,6 +537,7 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
             cmds["INT"] = "Enter interactive mode with the model.";
             cmds["READ"] = "Send a file with context to the model.";
             cmds["RESET"] = "Clear chat history.";
+            cmds["/RESET"] = "Clear the UART screen and redraw the welcome banner.";
             cmds["/speak on"] = "Enable text-to-speech output for assistant replies.";
             cmds["/speak off"] = "Disable text-to-speech output.";
             cmds["CFG"] = "Show current configuration.";
@@ -551,6 +552,19 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         route_output("Available commands:", true);
         for (auto& key : cmds.getMemberNames()) {
             route_output("  " + key + " - " + cmds[key].asString(), true);
+        }
+        return result;
+    }
+    // ===== /RESET =====
+    else if (cmd_upper == "/RESET") {
+        if (getCurrentCommandSource() == CommandSource::SERIAL) {
+            serialResetTerminal();
+            result["status"] = "success";
+            result["message"] = "UART terminal reset.";
+        } else {
+            route_output("[Info] /RESET is only available over the serial terminal.", true);
+            result["status"] = "error";
+            result["message"] = "/RESET is only available over the serial terminal.";
         }
         return result;
     }

--- a/src/ollama_client.cpp
+++ b/src/ollama_client.cpp
@@ -184,6 +184,54 @@ namespace {
             pos = end + delimiter.length();
         }
     }
+
+    void writeThinkingStatusRaw(const std::string& text, bool use_serial) {
+        if (use_serial && serial_available) {
+            serialSend(text);
+        } else {
+            std::cout << text;
+            std::cout.flush();
+        }
+    }
+
+    class ThinkingSpinner {
+    public:
+        explicit ThinkingSpinner(bool use_serial) : use_serial_(use_serial) {}
+
+        void start() {
+            active_.store(true, std::memory_order_relaxed);
+            writeThinkingStatusRaw("[Thinking -]", use_serial_);
+            worker_ = std::thread([this]() {
+                static constexpr char frames[] = {'-', '/', '-', '\\'};
+                std::size_t idx = 1;
+                using namespace std::chrono_literals;
+                while (active_.load(std::memory_order_relaxed)) {
+                    std::this_thread::sleep_for(150ms);
+                    if (!active_.load(std::memory_order_relaxed)) break;
+                    std::string update = "\b\b";
+                    update.push_back(frames[idx]);
+                    update.push_back(']');
+                    writeThinkingStatusRaw(update, use_serial_);
+                    idx = (idx + 1) % 4;
+                }
+            });
+        }
+
+        void stop(bool newline) {
+            const bool was_active = active_.exchange(false, std::memory_order_relaxed);
+            if (worker_.joinable()) worker_.join();
+            if (was_active && newline) writeThinkingStatusRaw("\n", use_serial_);
+        }
+
+        ~ThinkingSpinner() {
+            stop(false);
+        }
+
+    private:
+        bool use_serial_ = false;
+        std::atomic<bool> active_{false};
+        std::thread worker_;
+    };
 }
 
 // ---- Send message to configured provider ----
@@ -199,7 +247,9 @@ static bool sendMessageToOllama(const std::string& query,
     StreamData streamData;
     const CommandSource prev = getCurrentCommandSource();
     setCurrentCommandSource(prev);
-    route_output("[Thinking.....:-).......]", true);
+    const bool use_serial_spinner = (prev == CommandSource::SERIAL);
+    ThinkingSpinner spinner(use_serial_spinner);
+    spinner.start();
     streamData.start_time = std::chrono::high_resolution_clock::now();
 
     std::unique_ptr<StreamingTTSPlayer> tts_player;
@@ -213,6 +263,7 @@ static bool sendMessageToOllama(const std::string& query,
         [&](const std::string& text) {
             if (!streamData.first_chunk_received) {
                 streamData.first_chunk_received = true;
+                spinner.stop(true);
                 auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::high_resolution_clock::now() - streamData.start_time
                 ).count();
@@ -232,6 +283,7 @@ static bool sendMessageToOllama(const std::string& query,
         providerResult
     );
 
+    if (!streamData.first_chunk_received) spinner.stop(true);
     route_output("", true);
     setCurrentCommandSource(prev);
     if (tts_player) tts_player->finish();

--- a/src/ollama_client.cpp
+++ b/src/ollama_client.cpp
@@ -400,6 +400,12 @@ static std::string rtrim(std::string s){
 }
 static std::string trim(std::string s){ return rtrim(ltrim(s)); }
 
+static bool eq_ci(const std::string& a, const std::string& b){
+    if (a.size()!=b.size()) return false;
+    for (size_t i=0;i<a.size();++i) if (std::tolower((unsigned char)a[i])!=std::tolower((unsigned char)b[i])) return false;
+    return true;
+}
+
 // ================= Dispatcher =================
 Json::Value processCommand(const std::string& command, AppConfig& config) {
 
@@ -429,6 +435,65 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         route_output(speak.message, true);
         result["status"] = (cmd_upper == "/SPEAK ON" || cmd_upper == "/SPEAK OFF") ? "success" : "error";
         result["tts_enabled"] = config.tts_enabled;
+        return result;
+    }
+    if (cmd_upper == "/SOUND" || cmd_upper.rfind("/SOUND ", 0) == 0) {
+        std::string arg = command.size() > 6 ? trim(command.substr(6)) : "";
+        std::string device_error;
+        auto devices = listPlaybackDevices(device_error);
+        Json::Value device_list(Json::arrayValue);
+        for (const auto& device : devices) {
+            Json::Value item(Json::objectValue);
+            item["id"] = device.id;
+            item["description"] = device.description;
+            item["default"] = device.is_default;
+            item["current"] = (device.id == config.tts_output_device);
+            device_list.append(item);
+        }
+        result["devices"] = device_list;
+
+        if (arg.empty()) {
+            route_output("Available sound output devices:", true);
+            for (size_t i = 0; i < devices.size(); ++i) {
+                std::string line = "  [" + std::to_string(i + 1) + "] " + devices[i].id + " - " + devices[i].description;
+                if (devices[i].is_default) line += " (default)";
+                if (devices[i].id == config.tts_output_device) line += " (current)";
+                route_output(line, true);
+            }
+            if (!device_error.empty()) route_output(std::string("[Warn] ") + device_error, true);
+            route_output("Use: /sound <#|device> to set the TTS output device.", true);
+            result["status"] = "success";
+            return result;
+        }
+
+        int idx = -1;
+        try { idx = std::stoi(arg); } catch (...) { idx = -1; }
+        std::string chosen;
+        if (idx >= 1 && idx <= (int)devices.size()) {
+            chosen = devices[idx - 1].id;
+        } else {
+            for (const auto& device : devices) {
+                if (device.id == arg || eq_ci(device.id, arg) || eq_ci(device.description, arg)) {
+                    chosen = device.id;
+                    break;
+                }
+            }
+        }
+
+        if (chosen.empty()) {
+            route_output(std::string("[Error] Sound device not found: ") + arg, true);
+            result["status"] = "error";
+            return result;
+        }
+
+        config.tts_output_device = chosen;
+        result["tts_output_device"] = chosen;
+        if (saveConfig("config.txt", config)) {
+            route_output(std::string("[OK] tts_output_device=") + chosen + " (saved)", true);
+        } else {
+            route_output(std::string("[OK] tts_output_device=") + chosen + " (save failed)", true);
+        }
+        result["status"] = "success";
         return result;
     }
 
@@ -539,6 +604,7 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         result["tts_timeout_seconds"] = Json::Value(static_cast<Json::UInt64>(config.tts_timeout_seconds));
         result["tts_voice"] = config.tts_voice;
         result["tts_speaker"] = config.tts_speaker;
+        result["tts_output_device"] = config.tts_output_device;
         route_output("Current configuration:", true);
         route_output(std::string("\tSerial port: ") + config.serial_port, true);
         route_output(std::string("\tBaudrate: ") + std::to_string(config.baudrate), true);
@@ -551,6 +617,7 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         route_output(std::string("\tRAG threshold (ASK/INT): ") + std::to_string(config.rag_threshold), true);
         route_output(std::string("\tChar delay: ") + std::to_string(config.serial_delay_ms), true);
         route_output(std::string("\tNewline: ") + config.serial_newline, true);
+        route_output(std::string("\tTTS output device: ") + config.tts_output_device, true);
         return result;
     }
     // ===== DELAY =====
@@ -591,6 +658,7 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
             cmds["/RESET"] = "Clear the UART screen and redraw the welcome banner.";
             cmds["/speak on"] = "Enable text-to-speech output for assistant replies.";
             cmds["/speak off"] = "Disable text-to-speech output.";
+            cmds["/sound"] = "List or set the TTS output device.";
             cmds["CFG"] = "Show current configuration.";
             cmds["HELP"] = "List available commands.";
             cmds["MODEL"] = "List or set Ollama model.";
@@ -659,11 +727,6 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         if (idx >= 1 && idx <= (int)models.size()) {
             chosen = models[idx-1];
         } else {
-            auto eq_ci = [](const std::string& a, const std::string& b){
-                if (a.size()!=b.size()) return false;
-                for (size_t i=0;i<a.size();++i) if (std::tolower((unsigned char)a[i])!=std::tolower((unsigned char)b[i])) return false;
-                return true;
-            };
             for (auto& m : models) if (m == arg || eq_ci(m, arg)) { chosen = m; break; }
         }
 

--- a/src/ollama_client.cpp
+++ b/src/ollama_client.cpp
@@ -289,8 +289,8 @@ bool SerialINT_IsActive() {
 void SerialINT_Start(AppConfig& config) {
     g_serial_int_active.store(true, std::memory_order_relaxed);
     diag_log("[DIAG] INT called from source=%d\n", (int)getCurrentCommandSource());
-    route_output("[Interactive Mode] Type your messages. Type /bye to exit.\n", true);
-    route_output("-> ");
+    route_output("[Interactive Mode] Type your messages. Type /bye to exit.", true);
+    route_output("-> ", false);
 }
 
 void SerialINT_HandleLine(const std::string& line, AppConfig& config) {
@@ -422,6 +422,7 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
     else if (cmd_upper == "INT") {
         SerialINT_Start(config);
         result["status"] = "success";
+        result["prompt_emitted"] = true;
         return result;
     }
     // ===== READ =====
@@ -498,7 +499,6 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         route_output(std::string("\tRAG threshold (ASK/INT): ") + std::to_string(config.rag_threshold), true);
         route_output(std::string("\tChar delay: ") + std::to_string(config.serial_delay_ms), true);
         route_output(std::string("\tNewline: ") + config.serial_newline, true);
-        route_output("->", false);
         return result;
     }
     // ===== DELAY =====
@@ -521,7 +521,6 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
         } else {
             route_output(std::string("[OK] serial_delay_ms=") + std::to_string(ms) + " (save failed)", true);
         }
-        route_output("->", false);
         return Json::Value();
     }
     // ===== HELP =====
@@ -561,6 +560,7 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
             serialResetTerminal(config);
             result["status"] = "success";
             result["message"] = "UART terminal reset.";
+            result["prompt_emitted"] = true;
         } else {
             route_output("[Info] /RESET is only available over the serial terminal.", true);
             result["status"] = "error";

--- a/src/ollama_client.cpp
+++ b/src/ollama_client.cpp
@@ -558,7 +558,7 @@ Json::Value processCommand(const std::string& command, AppConfig& config) {
     // ===== /RESET =====
     else if (cmd_upper == "/RESET") {
         if (getCurrentCommandSource() == CommandSource::SERIAL) {
-            serialResetTerminal();
+            serialResetTerminal(config);
             result["status"] = "success";
             result["message"] = "UART terminal reset.";
         } else {

--- a/src/serial_handler.cpp
+++ b/src/serial_handler.cpp
@@ -14,6 +14,8 @@
 #include <libserialport.h>
 #include "serial_handler.h"
 #include "io_sink.h"
+#include "config_loader.h"
+#include "ollama_client.h"
 
 bool serial_available = false;
 static sp_port* serial_port = nullptr;
@@ -76,7 +78,7 @@ static std::string load_welcome_message() {
     return "Welcome to AImaster\n";
 }
 
-void serialResetTerminal() {
+void serialResetTerminal(const AppConfig& config) {
     if (!serial_available || serial_port == nullptr) return;
     serialSend("\f");
     using namespace std::chrono_literals;
@@ -90,7 +92,11 @@ void serialResetTerminal() {
     serialSend("AImaster: Online\n");
     serialSend(": --> Type help for help!\n");
     serialSend("AImaster: AIinterface active\n\n");
-    emit_prompt();
+    if (SerialINT_IsActive()) {
+        serialSend("-> ");
+    } else {
+        serialSend(modelPrompt(config, "> "));
+    }
 }
 
 static bool set_port_config(sp_port* port_handle, int baudrate) {
@@ -123,7 +129,6 @@ bool initSerial(const std::string& port, int baudrate) {
     }
     serial_port = handle;
     serial_available = true;
-    serialResetTerminal();
     return true;
 }
 

--- a/src/serial_handler.cpp
+++ b/src/serial_handler.cpp
@@ -81,6 +81,10 @@ void serialResetTerminal() {
     serialSend("\f");
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(250ms);
+    // Some attached terminals need an explicit carriage return after form-feed
+    // or the first printable character of the banner can be dropped/skewed.
+    serialSend("\r");
+    std::this_thread::sleep_for(50ms);
     serialSend(load_welcome_message());
     serialSend("\nAImaster: Link active\n");
     serialSend("AImaster: Online\n");

--- a/src/serial_handler.cpp
+++ b/src/serial_handler.cpp
@@ -7,6 +7,8 @@
 #include <atomic>
 #include <mutex>
 #include <functional>
+#include <fstream>
+#include <sstream>
 
 #include <libserialport.h>
 #include "serial_handler.h"
@@ -23,6 +25,7 @@ static std::thread serial_thread;
 static std::atomic<bool> serial_thread_running{false};
 static std::function<void(const std::string&)> line_callback = nullptr;
 static std::string rx_buffer;
+static std::string welcome_message_file = "assets/welcome.txt";
 
 static int to_policy(const std::string& s) {
     std::string k; k.reserve(s.size());
@@ -41,6 +44,41 @@ void setSerialNewlinePolicy(const std::string& policy) {
 void setSerialSendDelay(int delay_ms) {
     if (delay_ms < 0) delay_ms = 0;
     serial_send_delay_ms.store(delay_ms, std::memory_order_relaxed);
+}
+
+void setWelcomeMessageFile(const std::string& path) {
+    if (!path.empty()) welcome_message_file = path;
+}
+
+static std::string load_welcome_message() {
+    std::ifstream in(welcome_message_file);
+    if (!in) {
+        return "Welcome to AImaster\n";
+    }
+
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    std::string message = buffer.str();
+    if (message.empty()) {
+        return "Welcome to AImaster\n";
+    }
+    if (message.back() != '\n') {
+        message.push_back('\n');
+    }
+    return message;
+}
+
+void serialResetTerminal() {
+    if (!serial_available || serial_port == nullptr) return;
+    serialSend("\f");
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(250ms);
+    serialSend(load_welcome_message());
+    serialSend("\nAImaster: Link active\n");
+    serialSend("AImaster: Online\n");
+    serialSend(": --> Type help for help!\n");
+    serialSend("AImaster: AIinterface active\n\n");
+    emit_prompt();
 }
 
 static bool set_port_config(sp_port* port_handle, int baudrate) {
@@ -73,25 +111,7 @@ bool initSerial(const std::string& port, int baudrate) {
     }
     serial_port = handle;
     serial_available = true;
-    //outln("AImaster: Serial link active");
-    //emit_prompt();
-
-    // Optional: announce
-    serialSend("\f");
-    using namespace std::chrono_literals;
-    std::this_thread::sleep_for(1234ms);
-    serialSend("Welcome to AImaster\n\n");
-    std::this_thread::sleep_for(1234ms);
-    serialSend("AImaster: Link active\n");
-    std::this_thread::sleep_for(1234ms);
-    serialSend("AImaster: Online\n");
-    std::this_thread::sleep_for(1234ms);
-    serialSend(": --> Type help for help!\n");
-    std::this_thread::sleep_for(1234ms);
-    serialSend("AImaster: AIinterface active\n\n");
-    std::this_thread::sleep_for(1234ms);
-    emit_prompt();
-
+    serialResetTerminal();
     return true;
 }
 
@@ -191,13 +211,18 @@ bool serialReadLine(std::string& out, int timeout_ms) {
 
         int n = sp_nonblocking_read(serial_port, &byte, 1);
         if (n == 1) {
-            rx_buffer.push_back(byte);
+            const unsigned char ch = static_cast<unsigned char>(byte);
+            if (ch == 0x08 || ch == 0x7F) {
+                if (!rx_buffer.empty()) rx_buffer.pop_back();
+                continue;
+            }
             if (byte == '\n' || byte == '\r') {
                 out = rx_buffer;
                 rstrip_crlf(out);
                 rx_buffer.clear();
                 return true;
             }
+            rx_buffer.push_back(byte);
             if (rx_buffer.size() > 4096) {
                 out = rx_buffer;
                 rstrip_crlf(out);

--- a/src/serial_handler.cpp
+++ b/src/serial_handler.cpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <fstream>
 #include <sstream>
+#include <array>
 
 #include <libserialport.h>
 #include "serial_handler.h"
@@ -25,7 +26,7 @@ static std::thread serial_thread;
 static std::atomic<bool> serial_thread_running{false};
 static std::function<void(const std::string&)> line_callback = nullptr;
 static std::string rx_buffer;
-static std::string welcome_message_file = "assets/welcome.txt";
+static std::string welcome_message_file = "/usr/share/aimaster/welcome.txt";
 
 static int to_policy(const std::string& s) {
     std::string k; k.reserve(s.size());
@@ -51,21 +52,28 @@ void setWelcomeMessageFile(const std::string& path) {
 }
 
 static std::string load_welcome_message() {
-    std::ifstream in(welcome_message_file);
-    if (!in) {
-        return "Welcome to AImaster\n";
+    const std::array<std::string, 3> candidates = {
+        welcome_message_file,
+        "/usr/share/aimaster/welcome.txt",
+        "assets/welcome.txt"
+    };
+
+    for (const auto& candidate : candidates) {
+        if (candidate.empty()) continue;
+        std::ifstream in(candidate);
+        if (!in) continue;
+
+        std::ostringstream buffer;
+        buffer << in.rdbuf();
+        std::string message = buffer.str();
+        if (message.empty()) continue;
+        if (message.back() != '\n') {
+            message.push_back('\n');
+        }
+        return message;
     }
 
-    std::ostringstream buffer;
-    buffer << in.rdbuf();
-    std::string message = buffer.str();
-    if (message.empty()) {
-        return "Welcome to AImaster\n";
-    }
-    if (message.back() != '\n') {
-        message.push_back('\n');
-    }
-    return message;
+    return "Welcome to AImaster\n";
 }
 
 void serialResetTerminal() {

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <set>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
@@ -161,7 +162,6 @@ bool runPlayback(const std::vector<std::string>& argv, std::string& error) {
     return true;
 }
 
-
 std::vector<std::string> playbackBackendOrder() {
     std::vector<std::string> order;
     const char* env = std::getenv("AIMASTER_TTS_BACKENDS");
@@ -181,7 +181,7 @@ std::vector<std::string> playbackBackendOrder() {
     return order;
 }
 
-bool playAudioBytes(const std::vector<unsigned char>& audio, std::string& backend_used, std::string& error) {
+bool playAudioBytes(const std::vector<unsigned char>& audio, const AppConfig& config, std::string& backend_used, std::string& error) {
     std::string path;
     if (!writeAudioTempFile(audio, path, error)) return false;
 
@@ -196,7 +196,15 @@ bool playAudioBytes(const std::vector<unsigned char>& audio, std::string& backen
     for (const auto& name : order) {
         if (!findExecutable(name, exe)) continue;
         if (name == "paplay") backends.push_back({"paplay", {exe, path}});
-        else if (name == "aplay") backends.push_back({"aplay", {exe, "-q", path}});
+        else if (name == "aplay") {
+            std::vector<std::string> args{exe, "-q"};
+            if (!config.tts_output_device.empty()) {
+                args.push_back("-D");
+                args.push_back(config.tts_output_device);
+            }
+            args.push_back(path);
+            backends.push_back({"aplay", std::move(args)});
+        }
         else if (name == "ffplay") backends.push_back({"ffplay", {exe, "-nodisp", "-autoexit", "-loglevel", "error", path}});
     }
 
@@ -221,6 +229,35 @@ bool playAudioBytes(const std::vector<unsigned char>& audio, std::string& backen
 }
 
 } // namespace
+
+std::vector<PlaybackDevice> listPlaybackDevices(std::string& error) {
+    std::vector<PlaybackDevice> devices;
+    devices.push_back({"plughw:0,0", "Linux default card0,0", true});
+
+    FILE* pipe = ::popen("aplay -l 2>/dev/null", "r");
+    if (!pipe) {
+        error = "unable to execute 'aplay -l'";
+        return devices;
+    }
+
+    char buffer[512];
+    std::set<std::string> seen = {"plughw:0,0"};
+    while (std::fgets(buffer, sizeof(buffer), pipe)) {
+        std::string line = trim_copy(buffer);
+        if (line.rfind("card ", 0) != 0) continue;
+
+        int card = -1;
+        int device = -1;
+        if (std::sscanf(line.c_str(), "card %d: %*[^,], device %d:", &card, &device) != 2) continue;
+
+        std::string id = "plughw:" + std::to_string(card) + "," + std::to_string(device);
+        if (!seen.insert(id).second) continue;
+        devices.push_back({id, line, card == 0 && device == 0});
+    }
+
+    ::pclose(pipe);
+    return devices;
+}
 
 SpeakCommandResult parseSpeakCommand(const std::string& command) {
     SpeakCommandResult out;
@@ -448,7 +485,7 @@ static bool speakTextNow(const std::string& text, const AppConfig& config) {
 
     std::string backend_used;
     for (const auto& chunk : audio_chunks) {
-        if (!playAudioBytes(chunk, backend_used, error)) {
+        if (!playAudioBytes(chunk, config, backend_used, error)) {
             std::cerr << "[Warn] TTS playback failed: " << error << "\n";
             return false;
         }

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -454,7 +454,6 @@ static bool speakTextNow(const std::string& text, const AppConfig& config) {
         }
     }
 
-    std::cerr << "[Info] TTS playback backend: " << backend_used << "\n";
     return true;
 }
 


### PR DESCRIPTION
### Motivation

- Make the UART startup banner configurable and file-backed so an ASCII-art welcome message (HOLLY 6000) can be shipped and edited separately. 
- Provide a serial-only reset command to clear the terminal and redraw that banner. 
- Fix incoming serial line ingestion so backspace/delete sent by devices (e.g., Acorn Electron) edit the buffer before the LLM receives the string.

### Description

- Added a `welcome_message_file` field to `AppConfig` and wired it into `loadConfig`/`saveConfig` and the example config as `welcome_message_file=assets/welcome.txt`.
- Added `assets/welcome.txt` containing the HOLLY 6000 ASCII art with all lines kept within the requested 78-character width.
- Implemented `setWelcomeMessageFile` and `serialResetTerminal` in `src/serial_handler.cpp`, and made `initSerial` call `serialResetTerminal` to load/print the banner on serial startup.
- Implemented `load_welcome_message()` which reads the banner file, and used it when resetting the terminal; exposed `serialResetTerminal` in `include/serial_handler.h`.
- Updated `serialReadLine` to treat `0x08` and `0x7F` as backspace/delete and remove the previous character from the receive buffer before delivering the line.
- Added a serial-only `/RESET` command handler in `processCommand` and documented the command in `cmds.csv` and help output.
- Wired `setWelcomeMessageFile(config.welcome_message_file)` in `main` after `loadConfig` so the configured file path is used at runtime.

### Testing

- Ran `make` in this environment but the build could not complete because `json/json.h` was not found in the current include setup, so a full build/test was not possible here.
- Attempted targeted compilation of serial sources but compilation stopped due to missing `libserialport.h` in the environment, preventing runtime verification against a real serial device.
- Verified the banner file contents and line lengths and confirmed the new files and source edits are present and syntactically integrated (files written: `assets/welcome.txt`, updated `include/config_loader.h`, `src/config_loader.cpp`, `include/serial_handler.h`, `src/serial_handler.cpp`, `src/main.cpp`, `src/ollama_client.cpp`, `cmds.csv`, and `config-example.txt`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02cd7bb78832d8bacf6e59e7975e8)